### PR TITLE
Implicit NK_CONSOLE_IMPLEMENTATION

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Console-like user interface for [Nuklear](https://github.com/Immediate-Mode-UI/N
 ``` c
 #define NK_IMPLEMENTATION
 #include "nukear.h"
+
+#define NK_GAMEPAD_IMPLEMENTATION
+#include "nuklear_gamepad.h"
+
+#define NK_CONSOLE_IMPLEMENTATION
 #include "nuklear_console.h"
 
 int main() {
@@ -47,6 +52,7 @@ int main() {
 - Property
 - Slider
 - Tooltip
+- Rows
 
 ## API
 

--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -1,7 +1,12 @@
-#include "../../nuklear_console.h"
 #include "../../vendor/Nuklear/demo/common/style.c"
 
-struct nk_console* console;
+#define NK_GAMEPAD_IMPLEMENTATION
+#include "../../vendor/nuklear_gamepad/nuklear_gamepad.h"
+
+#define NK_CONSOLE_IMPLEMENTATION
+#include "../../nuklear_console.h"
+
+static struct nk_console* console = NULL;
 static nk_size progressValue = 50;
 static int weapon = 1;
 static int property_int_test = 20;
@@ -9,8 +14,8 @@ static float property_float_test = 0.4f;
 static int slider_int_test = 20;
 static float slider_float_test = 0.4f;
 static int theme = 4;
-nk_bool showWindowTitle = nk_true;
-nk_bool shouldClose = nk_false;
+static nk_bool showWindowTitle = nk_true;
+static nk_bool shouldClose = nk_false;
 
 void button_clicked(struct nk_console* button) {
     if (strcmp(button->text, "Quit Game") == 0) {

--- a/demo/raylib/main.c
+++ b/demo/raylib/main.c
@@ -1,8 +1,7 @@
 #define RAYLIB_NUKLEAR_IMPLEMENTATION
 #define RAYLIB_NUKLEAR_INCLUDE_DEFAULT_FONT
-#define NK_GAMEPAD_RAYLIB
 #include "raylib-nuklear.h"
-#include "../../nuklear_console.h"
+
 #include "../common/nuklear_console_demo.c"
 
 int main() {

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -114,13 +114,15 @@ NK_API void nk_console_mfree(nk_handle unused, void *ptr);
 NK_API nk_bool nk_console_button_pushed(nk_console* console, int button);
 NK_API void nk_console_set_gamepad(nk_console* console, struct nk_gamepads* gamepads);
 
-#include "nuklear_console_button.h"
+#define NK_CONSOLE_HEADER_ONLY
 #include "nuklear_console_label.h"
+#include "nuklear_console_button.h"
 #include "nuklear_console_checkbox.h"
 #include "nuklear_console_progress.h"
 #include "nuklear_console_combobox.h"
 #include "nuklear_console_property.h"
 #include "nuklear_console_row.h"
+#undef NK_CONSOLE_HEADER_ONLY
 
 #ifdef __cplusplus
 }
@@ -128,7 +130,7 @@ NK_API void nk_console_set_gamepad(nk_console* console, struct nk_gamepads* game
 
 #endif  // NK_CONSOLE_H__
 
-#ifdef NK_IMPLEMENTATION
+#ifdef NK_CONSOLE_IMPLEMENTATION
 #ifndef NK_CONSOLE_IMPLEMENTATION_ONCE
 #define NK_CONSOLE_IMPLEMENTATION_ONCE
 
@@ -159,27 +161,19 @@ NK_API void nk_console_set_gamepad(nk_console* console, struct nk_gamepads* game
 #endif
 #endif
 
-#ifndef NK_CONSOLE_GAMEPAD_H
-#define NK_CONSOLE_GAMEPAD_H "vendor/nuklear_gamepad/nuklear_gamepad.h"
-#endif
-#include NK_CONSOLE_GAMEPAD_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 NK_API nk_bool nk_input_is_mouse_moved(const struct nk_input* input);
 
-#ifndef NK_CONSOLE_IMPLEMENTATION
-#define NK_CONSOLE_IMPLEMENTATION
-#include "nuklear_console_button.h"
 #include "nuklear_console_label.h"
+#include "nuklear_console_button.h"
 #include "nuklear_console_checkbox.h"
 #include "nuklear_console_progress.h"
 #include "nuklear_console_combobox.h"
 #include "nuklear_console_property.h"
 #include "nuklear_console_row.h"
-#endif
 
 NK_API void nk_console_set_active_widget(nk_console* widget) {
     if (widget == NULL) {

--- a/nuklear_console_button.h
+++ b/nuklear_console_button.h
@@ -16,7 +16,7 @@ NK_API nk_console* nk_console_button_onclick(nk_console* parent, const char* tex
 
 #endif // NK_CONSOLE_BUTTON_H__
 
-#ifdef NK_CONSOLE_IMPLEMENTATION
+#if defined(NK_CONSOLE_IMPLEMENTATION) && !defined(NK_CONSOLE_HEADER_ONLY)
 #ifndef NK_CONSOLE_BUTTON_IMPLEMENTATION_ONCE
 #define NK_CONSOLE_BUTTON_IMPLEMENTATION_ONCE
 

--- a/nuklear_console_checkbox.h
+++ b/nuklear_console_checkbox.h
@@ -14,7 +14,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console);
 
 #endif // NK_CONSOLE_CHECKBOX_H__
 
-#ifdef NK_CONSOLE_IMPLEMENTATION
+#if defined(NK_CONSOLE_IMPLEMENTATION) && !defined(NK_CONSOLE_HEADER_ONLY)
 #ifndef NK_CONSOLE_CHECKBOX_IMPLEMENTATION_ONCE
 #define NK_CONSOLE_CHECKBOX_IMPLEMENTATION_ONCE
 

--- a/nuklear_console_combobox.h
+++ b/nuklear_console_combobox.h
@@ -16,7 +16,7 @@ NK_API void nk_console_combobox_button_main_click(nk_console* button);
 
 #endif // NK_CONSOLE_COMBOBOX_H__
 
-#ifdef NK_CONSOLE_IMPLEMENTATION
+#if defined(NK_CONSOLE_IMPLEMENTATION) && !defined(NK_CONSOLE_HEADER_ONLY)
 #ifndef NK_CONSOLE_COMBOBOX_IMPLEMENTATION_ONCE
 #define NK_CONSOLE_COMBOBOX_IMPLEMENTATION_ONCE
 

--- a/nuklear_console_label.h
+++ b/nuklear_console_label.h
@@ -14,7 +14,7 @@ NK_API struct nk_rect nk_console_label_render(nk_console* widget);
 
 #endif // NK_CONSOLE_LABEL_H__
 
-#ifdef NK_CONSOLE_IMPLEMENTATION
+#if defined(NK_CONSOLE_IMPLEMENTATION) && !defined(NK_CONSOLE_HEADER_ONLY)
 #ifndef NK_CONSOLE_LABEL_IMPLEMENTATION_ONCE
 #define NK_CONSOLE_LABEL_IMPLEMENTATION_ONCE
 

--- a/nuklear_console_progress.h
+++ b/nuklear_console_progress.h
@@ -14,7 +14,7 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console);
 
 #endif // NK_CONSOLE_PROGRESS_H__
 
-#ifdef NK_CONSOLE_IMPLEMENTATION
+#if defined(NK_CONSOLE_IMPLEMENTATION) && !defined(NK_CONSOLE_HEADER_ONLY)
 #ifndef NK_CONSOLE_PROGRESS_IMPLEMENTATION_ONCE
 #define NK_CONSOLE_PROGRESS_IMPLEMENTATION_ONCE
 

--- a/nuklear_console_property.h
+++ b/nuklear_console_property.h
@@ -17,7 +17,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console);
 
 #endif // NK_CONSOLE_PROPERTY_H__
 
-#ifdef NK_CONSOLE_IMPLEMENTATION
+#if defined(NK_CONSOLE_IMPLEMENTATION) && !defined(NK_CONSOLE_HEADER_ONLY)
 #ifndef NK_CONSOLE_PROPERTY_IMPLEMENTATION_ONCE
 #define NK_CONSOLE_PROPERTY_IMPLEMENTATION_ONCE
 

--- a/nuklear_console_row.h
+++ b/nuklear_console_row.h
@@ -30,9 +30,11 @@ NK_API struct nk_rect nk_console_row_render(nk_console* console);
 
 #endif  // NK_CONSOLE_ROW_H__
 
-#ifdef NK_CONSOLE_IMPLEMENTATION
+#if defined(NK_CONSOLE_IMPLEMENTATION) && !defined(NK_CONSOLE_HEADER_ONLY)
 #ifndef NK_CONSOLE_ROW_IMPLEMENTATION_ONCE
 #define NK_CONSOLE_ROW_IMPLEMENTATION_ONCE
+
+#include <stddef.h> // offsetof
 
 #if defined(__cplusplus)
 extern "C" {


### PR DESCRIPTION
This change makes a change to require a definition of `NK_CONSOLE_IMPLEMENTATION` to allow more control over when it's included.
