### PR TITLE
Expand callback capabilities

### DIFF
--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -222,7 +222,7 @@ nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_data, s
     }
 
     nk_console* theme_options = nk_console_combobox(console, "Theme", "Black;White;Red;Blue;Dark;Dracula;Default", ';', &theme);
-    theme_options->onchange = theme_changed;
+    nk_console_set_onchange(theme_options, &theme_changed);
     theme_options->tooltip = "Change the theme of the console!";
     set_style(ctx, (enum theme)theme);
 

--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -35,6 +35,8 @@ static float slider_float_test = 0.4f;
 static nk_bool checkbox1 = nk_false;
 static nk_bool checkbox2 = nk_false;
 static nk_bool checkbox3 = nk_false;
+static nk_bool checkbox4 = nk_false;
+static nk_bool checkbox5 = nk_false;
 
 // Messages
 static int message_count = 0;
@@ -62,6 +64,12 @@ void button_clicked(struct nk_console* button) {
 
 void theme_changed(struct nk_console* combobox) {
     set_style(combobox->ctx, (enum theme)theme);
+}
+
+void exlude_other_checkbox(nk_console_event_data data, nk_console* unused) {
+    NK_UNUSED(unused);
+    nk_console* other = (nk_console*)data.user;
+    other->disabled = !other->disabled;
 }
 
 void nk_console_demo_show_message(struct nk_console* button) {
@@ -115,6 +123,17 @@ nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_data, s
                 ->alignment = NK_TEXT_RIGHT;
             nk_console_checkbox(checkbox_button, "Disabled Checkbox", &checkbox2)
                 ->disabled = nk_true;
+
+            // Onchange callbacks can be used to implement custom logic.
+            // These two checkboxes disable each other when checked.
+            nk_console* exclude_a = nk_console_checkbox(checkbox_button, "Exclusive A (disables B)", &checkbox4);
+            nk_console* exclude_b = nk_console_checkbox(checkbox_button, "Exclusive B (disables A)", &checkbox5);
+            nk_console_event_handler handler = { &exlude_other_checkbox };
+            handler.data.user = exclude_b;
+            nk_console_set_onchange_handler(exclude_a, handler);
+            handler.data.user = exclude_a;
+            nk_console_set_onchange_handler(exclude_b, handler);
+
             nk_console_button_onclick(checkbox_button, "Back", nk_console_button_back);
         }
 

--- a/nuklear_console_button.h
+++ b/nuklear_console_button.h
@@ -241,6 +241,14 @@ NK_API void nk_console_button_back(nk_console* button) {
     }
 }
 
+static void nk_console_button_destroy(nk_console* button) {
+    nk_console_button_data* data = (nk_console_button_data*)button->data;
+    if (data == NULL) {
+        return;
+    }
+    nk_console_event_handler_destroy(&data->onclick, button);
+}
+
 NK_API nk_console* nk_console_button_onclick(nk_console* parent, const char* text, nk_console_event onclick) {
     nk_console_event_handler handler = {0};
     if (onclick) {
@@ -261,6 +269,7 @@ NK_API nk_console* nk_console_button_onclick_handler(nk_console* parent, const c
     button->selectable = nk_true;
     button->columns = 1;
     button->render = nk_console_button_render;
+    button->destroy = &nk_console_button_destroy;
     nk_console_button_set_onclick_handler(button, onclick);
     return button;
 }

--- a/nuklear_console_checkbox.h
+++ b/nuklear_console_checkbox.h
@@ -43,9 +43,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
             if (data->value_bool != NULL) {
                 *data->value_bool = !*data->value_bool;
-                if (console->onchange != NULL) {
-                    console->onchange(console);
-                }
+                nk_console_onchange(console);
             }
             active = nk_true;
             top->input_processed = nk_true;
@@ -53,9 +51,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
             if (data->value_bool != NULL) {
                 *data->value_bool = nk_false;
-                if (console->onchange != NULL) {
-                    console->onchange(console);
-                }
+                nk_console_onchange(console);
             }
             active = nk_true;
             top->input_processed = nk_true;
@@ -63,9 +59,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
             if (data->value_bool != NULL) {
                 *data->value_bool = nk_true;
-                if (console->onchange != NULL) {
-                    console->onchange(console);
-                }
+                nk_console_onchange(console);
             }
             active = nk_true;
             top->input_processed = nk_true;
@@ -97,8 +91,8 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
     }
 
     // Invoke onchanged event.
-    if (changed && console->onchange != NULL) {
-        console->onchange(console);
+    if (changed) {
+        nk_console_onchange(console);
     }
 
     if (console->disabled || !nk_console_is_active_widget(console)) {

--- a/nuklear_console_combobox.h
+++ b/nuklear_console_combobox.h
@@ -63,9 +63,7 @@ NK_API void nk_console_combobox_button_click(nk_console* button) {
     nk_console_button_back(button);
 
     // Invoke the onchange callback.
-    if (combobox->onchange != NULL) {
-        combobox->onchange(combobox);
-    }
+    nk_console_onchange(combobox);
 }
 
 /**
@@ -169,9 +167,7 @@ NK_API struct nk_rect nk_console_combobox_render(nk_console* console) {
             if (changed) {
                 console->label = console->children[*data->selected + 1]->label;
                 console->label_length = console->children[*data->selected + 1]->label_length;
-                if (console->onchange != NULL) {
-                    console->onchange(console);
-                }
+                nk_console_onchange(console);
             }
         }
     }

--- a/nuklear_console_file.h
+++ b/nuklear_console_file.h
@@ -248,9 +248,7 @@ NK_API void nk_console_file_entry_onclick(nk_console* button) {
                 data->file_path_buffer[desired_length] = '\0';
 
                 // Trigger the onchange event and exit.
-                if (file->onchange != NULL) {
-                    file->onchange(file);
-                }
+                nk_console_onchange(file);
             }
 
             // Now that we selected a file, we can exit.

--- a/nuklear_console_input.h
+++ b/nuklear_console_input.h
@@ -207,9 +207,7 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
         // Gamepad button pressed.
         if (nk_gamepad_any_button_pressed((struct nk_gamepads*)nk_console_get_gamepads(top), data->gamepad_number, data->out_gamepad_number, data->out_gamepad_button)) {
             // Trigger the onchange event and exit.
-            if (input->onchange != NULL) {
-                input->onchange(input);
-            }
+            nk_console_onchange(input);
             finished = nk_true;
         }
         // Any other input.

--- a/nuklear_console_progress.h
+++ b/nuklear_console_progress.h
@@ -65,9 +65,7 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
             if (data->value_size != NULL && *data->value_size > 0) {
                 *data->value_size = *data->value_size - 1;
-                if (console->onchange != NULL) {
-                    console->onchange(console);
-                }
+                nk_console_onchange(console);
             }
             active = nk_true;
             top->input_processed = nk_true;
@@ -75,9 +73,7 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
             if (data->value_size != NULL && *data->value_size < data->max_size) {
                 *data->value_size = *data->value_size + 1;
-                if (console->onchange != NULL) {
-                    console->onchange(console);
-                }
+                nk_console_onchange(console);
             }
             active = nk_true;
             top->input_processed = nk_true;
@@ -116,9 +112,7 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
 
     // Display the widget
     if (nk_progress(console->ctx, data->value_size, data->max_size, nk_true)) {
-        if (console->onchange != NULL) {
-            console->onchange(console);
-        }
+        nk_console_onchange(console);
     }
 
     // Restore the styles

--- a/nuklear_console_property.h
+++ b/nuklear_console_property.h
@@ -83,9 +83,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
                     // Nothing.
                     break;
             }
-            if (console->onchange != NULL) {
-                console->onchange(console);
-            }
+            nk_console_onchange(console);
             top->input_processed = nk_true;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
@@ -108,9 +106,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
                     // Nothing
                     break;
             }
-            if (console->onchange != NULL) {
-                console->onchange(console);
-            }
+            nk_console_onchange(console);
             top->input_processed = nk_true;
         }
     }


### PR DESCRIPTION
Fixes #69

A new struct `nk_console_event_handler ` is introduced to expand what callbacks can do by adding per-callback data and a destructor. The per-callback data is passed to every call and the destructor is called when overwriting the callback or when the associated widget is destroyed (exactly like c++ object lifetime).

This enables users to perform more complex logic and/or use the same callback for multiple widgets.

C++ wrappers are provided to allow users to easily set a C++ lambda as a callback:
```c++
nk_console_set_onchange_handler(console, [&](nk_console* console) {
        // Custom logic here
    });
```