### PR TITLE
Prevent NK_ASSERT error when minimizing or closing a console window.

### DIFF
--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -812,8 +812,10 @@ NK_API void nk_console_render_window(nk_console* console, const char* title, str
         return;
     }
 
-    nk_begin(console->ctx, title, bounds, flags);
-    nk_console_render(console);
+    if (nk_begin(console->ctx, title, bounds, flags)) {
+        nk_console_render(console);
+    }
+
     nk_end(console->ctx);
 }
 


### PR DESCRIPTION
See [`Immediate-Mode-UI/Nuklear/blob/master/src/nuklear_layout.c:85`](https://github.com/Immediate-Mode-UI/Nuklear/blob/a315d25b4c33efa0e112cab9562460e785935a10/src/nuklear_layout.c#L85)

```
/*  if one of these triggers you forgot to add an `if` condition around either
    a window, group, popup, combobox or contextual menu `begin` and `end` block.
    Example:
        if (nk_begin(...) {...} nk_end(...); or
        if (nk_group_begin(...) { nk_group_end(...);} */
```