### PR TITLE
Align C++ event APIs with C event APIs

### DIFF
--- a/nuklear_console.hpp
+++ b/nuklear_console.hpp
@@ -17,26 +17,16 @@ void nk_console_event_handler_destroy(nk_console*, void* user_data) {
 }
 
 template <typename T>
-void nk_console_set_event_handler(nk_console* widget, nk_console_event_type type, T&& t) {
+void nk_console_add_event_handler(nk_console* widget, nk_console_event_type type, T&& t) {
     void* memory = nk_console_malloc(nk_handle_id(0), NULL, sizeof(T));
     T* user_data = new (memory) T(std::move(t));
     nk_console_add_event_handler(widget, type, &nk_console_event_handler_call<T>, user_data, &nk_console_event_handler_destroy<T>);
 }
 
 template <typename T>
-void nk_console_set_onchange_handler(nk_console* widget, T&& t) {
-    nk_console_set_event_handler(widget, NK_CONSOLE_EVENT_CHANGED, std::move(t));
-}
-
-template <typename T>
-void nk_console_button_set_onclick_handler(nk_console* button, T&& t) {
-    nk_console_set_event_handler(button, NK_CONSOLE_EVENT_CLICKED, std::move(t));
-}
-
-template <typename T>
 nk_console* nk_console_button_onclick_handler(nk_console* parent, const char* text, T&& t) {
     nk_console* button = nk_console_button(parent, text);
-    nk_console_add_event(button, NK_CONSOLE_EVENT_CLICKED,  std::move(t));
+    nk_console_add_event_handler(button, NK_CONSOLE_EVENT_CLICKED, std::move(t));
     return button;
 }
 


### PR DESCRIPTION
The C API now uses nk_console_**add**_event_handler (not **_set_**)

Remove nk_console_set_onchange_handler and nk_console_button_set_onclick_handler which have no C equivalents