### PR TITLE
Add touch drag-to-scroll support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ void nk_console_set_active_widget(nk_console* widget);
 - [nuklear_gamepad](https://github.com/robloach/nuklear_gamepad)
 - [c-vector](https://github.com/eteran/c-vector/)
 
+## Configuration
+
+| Define | Description |
+| ------ | ----------- |
+| `NK_BUTTON_TRIGGER_ON_RELEASE` | When enabled, will allow for touch and drag to scroll the window |
+| `NK_CONSOLE_DRAG_THRESHOLD` | When using touch and drag to scroll, the amount of threshold movement needed to consider it a scroll |
+| `NK_CONSOLE_AXIS_DEADZONE` | The amount of movement the axis needs prior to moving the cursor |
+| `NK_CONSOLE_AXIS_REPEAT_INTERVAL` | When using the gamepad axis to move, how frequently the cursor will move |
+| `NK_CONSOLE_FILE_ADD_FILES` | The function callback used to enumerate files, see `nk_console_file_add_files_tinydir()` |
+
 ## Development
 
 Use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) to apply coding standards.

--- a/demo/raylib/main.c
+++ b/demo/raylib/main.c
@@ -7,6 +7,7 @@
 #define RAYLIB_NUKLEAR_IMPLEMENTATION
 #define RAYLIB_NUKLEAR_INCLUDE_DEFAULT_FONT
 #define NK_INCLUDE_DEFAULT_ALLOCATOR
+#define NK_BUTTON_TRIGGER_ON_RELEASE // Fixes some usage of touch and drag
 #include "raylib-nuklear.h"
 
 #include "../common/nuklear_console_demo.c"

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -159,6 +159,11 @@ typedef struct nk_console_top_data {
     nk_bool axis_down_fired; /** True this frame if an axis fired a down event. */
     nk_bool axis_left_fired; /** True this frame if an axis fired a left event. */
     nk_bool axis_right_fired; /** True this frame if an axis fired a right event. */
+
+    nk_bool drag_scroll_active; /** True when a drag-scroll gesture is in progress. */
+    struct nk_vec2 drag_scroll_origin; /** Mouse position when the drag started. */
+    nk_uint drag_scroll_start_x; /** Window scroll X at drag start. */
+    nk_uint drag_scroll_start_y; /** Window scroll Y at drag start. */
 } nk_console_top_data;
 
 #if defined(__cplusplus)
@@ -307,6 +312,9 @@ NK_API nk_bool nk_console_navigate_to_path(nk_console* console, const char* path
 #endif
 #ifndef NK_CONSOLE_AXIS_REPEAT_INTERVAL
 #define NK_CONSOLE_AXIS_REPEAT_INTERVAL 0.5f
+#endif
+#ifndef NK_CONSOLE_DRAG_THRESHOLD
+#define NK_CONSOLE_DRAG_THRESHOLD 8.0f
 #endif
 
 // NK_CONSOLE_MALLOC
@@ -1045,6 +1053,31 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
 
     // Process the Nuklear window.
     if (nk_begin(console->ctx, title, bounds, flags)) {
+        // Touch/drag-to-scroll: press and drag to scroll the window.
+        {
+            struct nk_input* in = &console->ctx->input;
+            if (nk_window_is_hovered(console->ctx) && nk_input_is_mouse_pressed(in, NK_BUTTON_LEFT)) {
+                top_data->drag_scroll_origin = in->mouse.pos;
+                nk_window_get_scroll(console->ctx, &top_data->drag_scroll_start_x, &top_data->drag_scroll_start_y);
+                top_data->drag_scroll_active = nk_false;
+            }
+            if (nk_input_is_mouse_down(in, NK_BUTTON_LEFT)) {
+                float dy = top_data->drag_scroll_origin.y - in->mouse.pos.y;
+                float dx = top_data->drag_scroll_origin.x - in->mouse.pos.x;
+                if (!top_data->drag_scroll_active &&
+                        (dy * dy + dx * dx) > NK_CONSOLE_DRAG_THRESHOLD * NK_CONSOLE_DRAG_THRESHOLD) {
+                    top_data->drag_scroll_active = nk_true;
+                }
+                if (top_data->drag_scroll_active) {
+                    nk_uint sx = (nk_uint)NK_MAX(0.0f, (float)top_data->drag_scroll_start_x + dx);
+                    nk_uint sy = (nk_uint)NK_MAX(0.0f, (float)top_data->drag_scroll_start_y + dy);
+                    nk_window_set_scroll(console->ctx, sx, sy);
+                    top_data->input_processed = nk_true;
+                }
+            } else {
+                top_data->drag_scroll_active = nk_false;
+            }
+        }
         nk_console_render(console);
     }
 

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -1371,7 +1371,7 @@ NK_API nk_bool nk_console_button_pushed(nk_console* console, int button) {
 
     // Gamepad
     nk_console_top_data* data = (nk_console_top_data*)console->data;
-    if (nk_gamepad_is_button_pressed(data->gamepads, data->gamepad_num, (enum nk_gamepad_button)button)) {
+    if (nk_gamepad_is_button_released(data->gamepads, data->gamepad_num, (enum nk_gamepad_button)button)) {
         return nk_true;
     }
 

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -164,6 +164,8 @@ typedef struct nk_console_top_data {
     struct nk_vec2 drag_scroll_origin; /** Mouse position when the drag started. */
     nk_uint drag_scroll_start_x; /** Window scroll X at drag start. */
     nk_uint drag_scroll_start_y; /** Window scroll Y at drag start. */
+    nk_uint drag_scroll_max_x; /** Maximum scroll X, updated each frame after render. */
+    nk_uint drag_scroll_max_y; /** Maximum scroll Y, updated each frame after render. */
 } nk_console_top_data;
 
 #if defined(__cplusplus)
@@ -870,6 +872,32 @@ static void nk_console_axis_update(nk_console* console) {
     }
 }
 
+    // Touch/drag-to-scroll: press and drag to scroll the window.
+static void nk_console_window_touch_drag(nk_console* console, nk_console_top_data* top_data) {
+    struct nk_input* in = &console->ctx->input;
+    if (nk_window_is_hovered(console->ctx) && nk_input_is_mouse_pressed(in, NK_BUTTON_LEFT)) {
+        top_data->drag_scroll_origin = in->mouse.pos;
+        nk_window_get_scroll(console->ctx, &top_data->drag_scroll_start_x, &top_data->drag_scroll_start_y);
+        top_data->drag_scroll_active = nk_false;
+    }
+    if (nk_input_is_mouse_down(in, NK_BUTTON_LEFT)) {
+        float dy = top_data->drag_scroll_origin.y - in->mouse.pos.y;
+        float dx = top_data->drag_scroll_origin.x - in->mouse.pos.x;
+        if (!top_data->drag_scroll_active &&
+                (dy * dy + dx * dx) > NK_CONSOLE_DRAG_THRESHOLD * NK_CONSOLE_DRAG_THRESHOLD) {
+            top_data->drag_scroll_active = nk_true;
+        }
+        if (top_data->drag_scroll_active) {
+            nk_uint sx = (nk_uint)NK_CLAMP(0.0f, (float)top_data->drag_scroll_start_x + dx, (float)top_data->drag_scroll_max_x);
+            nk_uint sy = (nk_uint)NK_CLAMP(0.0f, (float)top_data->drag_scroll_start_y + dy, (float)top_data->drag_scroll_max_y);
+            nk_window_set_scroll(console->ctx, sx, sy);
+            top_data->input_processed = nk_true;
+        }
+    } else {
+        top_data->drag_scroll_active = nk_false;
+    }
+}
+
 NK_API void nk_console_render(nk_console* console) {
     if (console == NULL || console->visible == nk_false) {
         return;
@@ -882,6 +910,7 @@ NK_API void nk_console_render(nk_console* console) {
         // Reset the input state and calculate new axis data.
         data->input_processed = nk_false;
         nk_console_axis_update(console);
+        nk_console_window_touch_drag(console, data);
 
         nk_console_trigger_event(data->active_parent, NK_CONSOLE_EVENT_PRE_PARENT_RENDER);
 
@@ -1053,31 +1082,6 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
 
     // Process the Nuklear window.
     if (nk_begin(console->ctx, title, bounds, flags)) {
-        // Touch/drag-to-scroll: press and drag to scroll the window.
-        {
-            struct nk_input* in = &console->ctx->input;
-            if (nk_window_is_hovered(console->ctx) && nk_input_is_mouse_pressed(in, NK_BUTTON_LEFT)) {
-                top_data->drag_scroll_origin = in->mouse.pos;
-                nk_window_get_scroll(console->ctx, &top_data->drag_scroll_start_x, &top_data->drag_scroll_start_y);
-                top_data->drag_scroll_active = nk_false;
-            }
-            if (nk_input_is_mouse_down(in, NK_BUTTON_LEFT)) {
-                float dy = top_data->drag_scroll_origin.y - in->mouse.pos.y;
-                float dx = top_data->drag_scroll_origin.x - in->mouse.pos.x;
-                if (!top_data->drag_scroll_active &&
-                        (dy * dy + dx * dx) > NK_CONSOLE_DRAG_THRESHOLD * NK_CONSOLE_DRAG_THRESHOLD) {
-                    top_data->drag_scroll_active = nk_true;
-                }
-                if (top_data->drag_scroll_active) {
-                    nk_uint sx = (nk_uint)NK_MAX(0.0f, (float)top_data->drag_scroll_start_x + dx);
-                    nk_uint sy = (nk_uint)NK_MAX(0.0f, (float)top_data->drag_scroll_start_y + dy);
-                    nk_window_set_scroll(console->ctx, sx, sy);
-                    top_data->input_processed = nk_true;
-                }
-            } else {
-                top_data->drag_scroll_active = nk_false;
-            }
-        }
         nk_console_render(console);
     }
 
@@ -1092,14 +1096,17 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
         }
     }
 
-    // Calculate the content size.
+    // Calculate the content size and scroll bounds.
     {
         struct nk_rect outer = nk_window_get_bounds(console->ctx);
         struct nk_rect content = nk_window_get_content_region(console->ctx);
         float chrome_h = outer.h - content.h;
         float rendered_h = console->ctx->current->layout->at_y - console->ctx->current->layout->bounds.y + console->ctx->current->layout->row.height;
+        float rendered_w = console->ctx->current->layout->max_x - console->ctx->current->layout->bounds.x;
         window_bounds = outer;
         window_bounds.h = chrome_h + rendered_h;
+        top_data->drag_scroll_max_y = (nk_uint)NK_MAX(0.0f, rendered_h - content.h);
+        top_data->drag_scroll_max_x = (nk_uint)NK_MAX(0.0f, rendered_w - content.w);
     }
 
     // Finish the window processing.

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -872,8 +872,14 @@ static void nk_console_axis_update(nk_console* console) {
     }
 }
 
-    // Touch/drag-to-scroll: press and drag to scroll the window.
+/**
+ * Handles the Touch and Drag Scrolling.
+ */
 static void nk_console_window_touch_drag(nk_console* console, nk_console_top_data* top_data) {
+#ifndef NK_BUTTON_TRIGGER_ON_RELEASE
+    NK_UNUSED(console);
+    NK_UNUSED(top_data);
+#else
     struct nk_input* in = &console->ctx->input;
     if (nk_window_is_hovered(console->ctx) && nk_input_is_mouse_pressed(in, NK_BUTTON_LEFT)) {
         top_data->drag_scroll_origin = in->mouse.pos;
@@ -896,6 +902,7 @@ static void nk_console_window_touch_drag(nk_console* console, nk_console_top_dat
     } else {
         top_data->drag_scroll_active = nk_false;
     }
+#endif
 }
 
 NK_API void nk_console_render(nk_console* console) {
@@ -1098,15 +1105,14 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
 
     // Calculate the content size and scroll bounds.
     {
-        struct nk_rect outer = nk_window_get_bounds(console->ctx);
         struct nk_rect content = nk_window_get_content_region(console->ctx);
-        float chrome_h = outer.h - content.h;
         float rendered_h = console->ctx->current->layout->at_y - console->ctx->current->layout->bounds.y + console->ctx->current->layout->row.height;
-        float rendered_w = console->ctx->current->layout->max_x - console->ctx->current->layout->bounds.x;
-        window_bounds = outer;
-        window_bounds.h = chrome_h + rendered_h;
+        window_bounds = nk_window_get_bounds(console->ctx);
+        window_bounds.h = window_bounds.h - content.h + rendered_h;
+#ifdef NK_BUTTON_TRIGGER_ON_RELEASE
         top_data->drag_scroll_max_y = (nk_uint)NK_MAX(0.0f, rendered_h - content.h);
-        top_data->drag_scroll_max_x = (nk_uint)NK_MAX(0.0f, rendered_w - content.w);
+        top_data->drag_scroll_max_x = (nk_uint)NK_MAX(0.0f, console->ctx->current->layout->max_x - console->ctx->current->layout->bounds.x - content.w);
+#endif
     }
 
     // Finish the window processing.


### PR DESCRIPTION
Press and drag within the window to scroll — works for mouse and touch (via SDL's touch-to-mouse conversion).

- Adds `drag_scroll_*` state fields to `nk_console_top_data`
- Adds `NK_CONSOLE_DRAG_THRESHOLD` constant (default 8px, overridable)
- Drag detected in `nk_console_render_window()` before widget render; sets `input_processed` while scrolling so widget clicks are suppressed