### PR TITLE
Key/Input: set default value on timeout

### DIFF
--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -359,10 +359,12 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         }
 
         // Input: From any gamepad (-1)
-        nk_console_input(widgets, "Input Button", -1, &gamepad_number, &gamepad_button);
+        nk_console* input_button = nk_console_input(widgets, "Input Button", -1, &gamepad_number, &gamepad_button);
+        nk_console_input_set_default(input_button, NK_GAMEPAD_BUTTON_INVALID);
 
         // Key: Capture a keyboard key binding
-        nk_console_key(widgets, "Key Binding", &key_binding);
+        nk_console* key_button = nk_console_key(widgets, "Key Binding", &key_binding);
+        nk_console_key_set_default(key_button, NK_KEY_NONE);
 
         // Combobox
         nk_console_combobox(widgets, "ComboBox", "Fists;Chainsaw;Pistol;Shotgun;Chaingun", ';', &weapon)

--- a/nuklear_console_input.h
+++ b/nuklear_console_input.h
@@ -12,6 +12,7 @@ typedef struct nk_console_input_data {
     int* out_gamepad_number; /** A pointer for where to store the gamepad number the button is associated with. */
     enum nk_gamepad_button* out_gamepad_button; /** A pointer to where to store the gamepad button. */
     float timer; /** A countdown timer to prompt the user with. @see NK_CONSOLE_INPUT_TIMER */
+    enum nk_gamepad_button default_gamepad_button; /** Value assigned to out_gamepad_button on timeout. @see nk_console_input_set_default */
 } nk_console_input_data;
 
 #if defined(__cplusplus)
@@ -33,6 +34,17 @@ extern "C" {
  */
 NK_API nk_console* nk_console_input(nk_console* parent, const char* label, int gamepad_number, int* out_gamepad_number, enum nk_gamepad_button* out_gamepad_button);
 NK_API struct nk_rect nk_console_input_render(nk_console* widget);
+
+/**
+ * Set the default gamepad button assigned to out_gamepad_button when the capture prompt times out.
+ * Defaults to NK_GAMEPAD_BUTTON_INVALID.
+ */
+NK_API void nk_console_input_set_default(nk_console* widget, enum nk_gamepad_button gamepad_button);
+
+/**
+ * Get the default gamepad button assigned to out_gamepad_button when the capture prompt times out.
+ */
+NK_API enum nk_gamepad_button nk_console_input_get_default(nk_console* widget);
 
 #if defined(__cplusplus)
 }
@@ -173,6 +185,9 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
 
     // Handle the timeout
     if (data->timer >= NK_CONSOLE_INPUT_TIMER) {
+        if (data->out_gamepad_button != NULL) {
+            *data->out_gamepad_button = data->default_gamepad_button;
+        }
         finished = nk_true;
     }
 
@@ -214,6 +229,20 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
     return nk_rect(0, 0, 0, 0);
 }
 
+NK_API void nk_console_input_set_default(nk_console* widget, enum nk_gamepad_button gamepad_button) {
+    if (widget == NULL || widget->data == NULL) {
+        return;
+    }
+    ((nk_console_input_data*)widget->data)->default_gamepad_button = gamepad_button;
+}
+
+NK_API enum nk_gamepad_button nk_console_input_get_default(nk_console* widget) {
+    if (widget == NULL || widget->data == NULL) {
+        return NK_GAMEPAD_BUTTON_INVALID;
+    }
+    return ((nk_console_input_data*)widget->data)->default_gamepad_button;
+}
+
 NK_API nk_console* nk_console_input(nk_console* parent, const char* label, int gamepad_number, int* out_gamepad_number, enum nk_gamepad_button* out_gamepad_button) {
     if (parent == NULL) {
         return NULL;
@@ -225,6 +254,7 @@ NK_API nk_console* nk_console_input(nk_console* parent, const char* label, int g
     data->gamepad_number = gamepad_number;
     data->out_gamepad_number = out_gamepad_number;
     data->out_gamepad_button = out_gamepad_button;
+    data->default_gamepad_button = NK_GAMEPAD_BUTTON_INVALID;
 
     nk_console* widget = nk_console_label(parent, label);
     widget->type = NK_CONSOLE_INPUT;

--- a/nuklear_console_key.h
+++ b/nuklear_console_key.h
@@ -15,6 +15,7 @@ typedef struct nk_console_key_data {
     struct nk_console_button_data button_data; /** Inherited from button */
     nk_rune* out_key; /** A pointer to where to store the captured key/character. */
     float timer; /** A countdown timer to prompt the user with. @see NK_CONSOLE_KEY_TIMER */
+    nk_rune default_key; /** Value assigned to out_key on timeout. @see nk_console_key_set_default */
 } nk_console_key_data;
 
 #if defined(__cplusplus)
@@ -37,6 +38,17 @@ NK_API struct nk_rect nk_console_key_render(nk_console* widget);
  * Retrieves the name of the of the given Nuklear rune.
  */
 NK_API const char* nk_console_key_name(nk_rune key);
+
+/**
+ * Set the default key value assigned to out_key when the capture prompt times out.
+ * Defaults to NK_KEY_NONE.
+ */
+NK_API void nk_console_key_set_default(nk_console* widget, nk_rune key);
+
+/**
+ * Get the default key value assigned to out_key when the capture prompt times out.
+ */
+NK_API nk_rune nk_console_key_get_default(nk_console* widget);
 
 #if defined(__cplusplus)
 }
@@ -209,6 +221,9 @@ static struct nk_rect nk_console_key_active_render(nk_console* console) {
     nk_bool finished = nk_false;
 
     if (data->timer >= NK_CONSOLE_KEY_TIMER) {
+        if (data->out_key != NULL) {
+            *data->out_key = data->default_key;
+        }
         finished = nk_true;
     }
 
@@ -271,6 +286,20 @@ static struct nk_rect nk_console_key_active_render(nk_console* console) {
     return nk_rect(0, 0, 0, 0);
 }
 
+NK_API void nk_console_key_set_default(nk_console* widget, nk_rune key) {
+    if (widget == NULL || widget->data == NULL) {
+        return;
+    }
+    ((nk_console_key_data*)widget->data)->default_key = key;
+}
+
+NK_API nk_rune nk_console_key_get_default(nk_console* widget) {
+    if (widget == NULL || widget->data == NULL) {
+        return NK_KEY_NONE;
+    }
+    return ((nk_console_key_data*)widget->data)->default_key;
+}
+
 NK_API nk_console* nk_console_key(nk_console* parent, const char* label, nk_rune* out_key) {
     if (parent == NULL) {
         return NULL;
@@ -279,6 +308,7 @@ NK_API nk_console* nk_console_key(nk_console* parent, const char* label, nk_rune
     nk_console_key_data* data = (nk_console_key_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_key_data));
     nk_zero(data, sizeof(nk_console_key_data));
     data->out_key = out_key;
+    data->default_key = NK_KEY_NONE;
 
     nk_console* widget = nk_console_label(parent, label);
     widget->type = NK_CONSOLE_KEY;


### PR DESCRIPTION
When the capture prompt times out, set the output to the default value (NK_KEY_NONE for Key, NK_GAMEPAD_BUTTON_INVALID for Input). Adds set/get default API functions for both widgets. Fixes #172