### PR TITLE
file: Add nk_console_file_action

### DIFF
--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -403,6 +403,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         nk_console* file_select = nk_console_file(widgets, "File", file_path_buffer, file_path_buffer_size);
         nk_console_file_set_list_view(file_select, nk_true);
         nk_console_dir(widgets, "Directory", dir_buffer, dir_buffer_size);
+        nk_console_file_action(widgets, "Select a File", file_path_buffer, file_path_buffer_size);
 
         // Messages
         nk_console_button_onclick(widgets, "Show Message", &nk_console_demo_show_message);

--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -133,6 +133,15 @@ void nk_console_quit_button_focused(struct nk_console* widget, void* user_data) 
     nk_console_show_message(widget, "Are you sure you want to quit?");
 }
 
+void nk_console_file_action_changed(struct nk_console* widget, void* user_data) {
+    NK_UNUSED(user_data);
+    nk_console_file_data* data = (nk_console_file_data*)widget->data;
+    char message[NK_CONSOLE_FILE_PATH_MAX + 32];
+    snprintf(message, sizeof(message), "Selected: %s", data->file_path_buffer);
+    nk_console_show_message(widget, message);
+    widget->disabled = nk_true;
+}
+
 void nk_console_radio_changed(struct nk_console* radio, void* user_data) {
     NK_UNUSED(user_data);
     nk_console_show_message(radio, radio->label);
@@ -403,7 +412,8 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         nk_console* file_select = nk_console_file(widgets, "File", file_path_buffer, file_path_buffer_size);
         nk_console_file_set_list_view(file_select, nk_true);
         nk_console_dir(widgets, "Directory", dir_buffer, dir_buffer_size);
-        nk_console_file_action(widgets, "Select a File", file_path_buffer, file_path_buffer_size);
+        nk_console* file_action = nk_console_file_action(widgets, "Select a File", file_path_buffer, file_path_buffer_size);
+        nk_console_add_event(file_action, NK_CONSOLE_EVENT_CHANGED, &nk_console_file_action_changed);
 
         // Messages
         nk_console_button_onclick(widgets, "Show Message", &nk_console_demo_show_message);

--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -414,6 +414,8 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         nk_console_dir(widgets, "Directory", dir_buffer, dir_buffer_size);
         nk_console* file_action = nk_console_file_action(widgets, "Select a File", file_path_buffer, file_path_buffer_size);
         nk_console_add_event(file_action, NK_CONSOLE_EVENT_CHANGED, &nk_console_file_action_changed);
+        nk_console* dir_action = nk_console_dir_action(widgets, "Select a Directory", dir_buffer, dir_buffer_size);
+        nk_console_add_event(dir_action, NK_CONSOLE_EVENT_CHANGED, &nk_console_file_action_changed);
 
         // Messages
         nk_console_button_onclick(widgets, "Show Message", &nk_console_demo_show_message);

--- a/nuklear_console_file.h
+++ b/nuklear_console_file.h
@@ -62,11 +62,11 @@ NK_API nk_console* nk_console_file(nk_console* parent, const char* label, char* 
 NK_API nk_console* nk_console_dir(nk_console* parent, const char* label, char* dir_buffer, int dir_buffer_size);
 
 /**
- * Creates a file action widget that shows a single button; after the user selects a file, the
- * widget is immediately disabled and cannot be used again.
+ * Creates a file action widget that shows a single full-width button. The label is used as the
+ * button text before a file is selected; afterwards the button shows the chosen filename.
  *
  * @param parent The parent widget.
- * @param label The label for the file widget. For example: "Select a file". Pass NULL for no label.
+ * @param label The button label. For example: "Select a file". Pass NULL for the default text.
  * @param file_path_buffer The buffer to store the file path.
  * @param file_path_buffer_size The size of the buffer.
  *
@@ -201,12 +201,6 @@ NK_API struct nk_rect nk_console_file_render(nk_console* console) {
     }
     nk_console_file_data* data = (nk_console_file_data*)console->data;
 
-    // In file_action mode, collapse to a single-column layout (no left label).
-    int orig_columns = console->columns;
-    if (data->file_action) {
-        console->columns = 1;
-    }
-
     nk_console_layout_widget(console);
 
     // Display the label (skipped in file_action mode — it becomes the button text instead).
@@ -226,21 +220,22 @@ NK_API struct nk_rect nk_console_file_render(nk_console* console) {
     }
 
     // Display the mocked button
-    const char* orig_label = console->label;
+    int swap_columns = console->columns;
+    const char* swap_label = console->label;
     console->columns = 0;
     if (data->file_path_buffer != NULL && data->file_path_buffer[0] != '\0') {
         console->label = nk_console_file_basename(data->file_path_buffer);
     }
-    else if (data->file_action && orig_label != NULL && orig_label[0] != '\0') {
+    else if (data->file_action && swap_label != NULL && swap_label[0] != '\0') {
         // In file_action mode, use the widget label as the button text.
-        console->label = orig_label;
+        console->label = swap_label;
     }
     else {
         console->label = data->select_directory ? "[Select Directory]" : "[Select a File]";
     }
     struct nk_rect widget_bounds = nk_console_button_render(console);
-    console->columns = orig_columns;
-    console->label = orig_label;
+    console->columns = swap_columns;
+    console->label = swap_label;
 
     return widget_bounds;
 }
@@ -849,6 +844,7 @@ NK_API nk_console* nk_console_file_action(nk_console* parent, const char* label,
 
     nk_console_file_data* data = (nk_console_file_data*)widget->data;
     data->file_action = nk_true;
+    widget->columns = 1;
 
     return widget;
 }

--- a/nuklear_console_file.h
+++ b/nuklear_console_file.h
@@ -28,7 +28,7 @@ typedef struct nk_console_file_data {
     void* file_user_data; /** Custom user data for the file system. */
     nk_bool select_directory; /** Flag indicating if we are selecting a directory. */
     nk_bool use_list_view; /** When true, uses a list view for file selection. Defaults to buttons. */
-    nk_bool file_action; /** When true, disables the widget after a file is selected. */
+    nk_bool file_action; /** When true, uses the label as the button text and skips the left-side label. */
     char dir_label_buf[NK_CONSOLE_FILE_PATH_MAX + 2]; /** Scratch buffer for appending "/" to directory labels in the list view. */
     nk_console_file_entry* entries; /** cvector of file/directory entries for the list view. */
 } nk_console_file_data;
@@ -414,9 +414,6 @@ static void nk_console_file_list_view_onclick(nk_console* list_view, void* user_
             NK_MEMCPY(data->file_path_buffer, data->directory, (nk_size)desired_length);
             data->file_path_buffer[desired_length] = '\0';
             nk_console_trigger_event(file, NK_CONSOLE_EVENT_CHANGED);
-            if (data->file_action) {
-                file->disabled = nk_true;
-            }
         }
 
         // Exit the file browser.
@@ -447,9 +444,6 @@ static void nk_console_file_select_dir_onclick(nk_console* button, void* user_da
         NK_MEMCPY(data->file_path_buffer, data->directory, (nk_size)desired_length);
         data->file_path_buffer[desired_length] = '\0';
         nk_console_trigger_event(file, NK_CONSOLE_EVENT_CHANGED);
-        if (data->file_action) {
-            file->disabled = nk_true;
-        }
     }
 
     // Exit the file browser.
@@ -510,9 +504,6 @@ static void nk_console_file_button_file_onclick(nk_console* button, void* user_d
         NK_MEMCPY(data->file_path_buffer, data->directory, (nk_size)desired_length);
         data->file_path_buffer[desired_length] = '\0';
         nk_console_trigger_event(file, NK_CONSOLE_EVENT_CHANGED);
-        if (data->file_action) {
-            file->disabled = nk_true;
-        }
     }
     nk_console_navigate_back(file);
 }

--- a/nuklear_console_file.h
+++ b/nuklear_console_file.h
@@ -28,6 +28,7 @@ typedef struct nk_console_file_data {
     void* file_user_data; /** Custom user data for the file system. */
     nk_bool select_directory; /** Flag indicating if we are selecting a directory. */
     nk_bool use_list_view; /** When true, uses a list view for file selection. Defaults to buttons. */
+    nk_bool file_action; /** When true, disables the widget after a file is selected. */
     char dir_label_buf[NK_CONSOLE_FILE_PATH_MAX + 2]; /** Scratch buffer for appending "/" to directory labels in the list view. */
     nk_console_file_entry* entries; /** cvector of file/directory entries for the list view. */
 } nk_console_file_data;
@@ -59,6 +60,19 @@ NK_API nk_console* nk_console_file(nk_console* parent, const char* label, char* 
  * @return The new file widget.
  */
 NK_API nk_console* nk_console_dir(nk_console* parent, const char* label, char* dir_buffer, int dir_buffer_size);
+
+/**
+ * Creates a file action widget that shows a single button; after the user selects a file, the
+ * widget is immediately disabled and cannot be used again.
+ *
+ * @param parent The parent widget.
+ * @param label The label for the file widget. For example: "Select a file". Pass NULL for no label.
+ * @param file_path_buffer The buffer to store the file path.
+ * @param file_path_buffer_size The size of the buffer.
+ *
+ * @return The new file action widget.
+ */
+NK_API nk_console* nk_console_file_action(nk_console* parent, const char* label, char* file_path_buffer, int file_path_buffer_size);
 
 /**
  * Render callback to display the file widget.
@@ -391,6 +405,9 @@ static void nk_console_file_list_view_onclick(nk_console* list_view, void* user_
             NK_MEMCPY(data->file_path_buffer, data->directory, (nk_size)desired_length);
             data->file_path_buffer[desired_length] = '\0';
             nk_console_trigger_event(file, NK_CONSOLE_EVENT_CHANGED);
+            if (data->file_action) {
+                file->disabled = nk_true;
+            }
         }
 
         // Exit the file browser.
@@ -421,6 +438,9 @@ static void nk_console_file_select_dir_onclick(nk_console* button, void* user_da
         NK_MEMCPY(data->file_path_buffer, data->directory, (nk_size)desired_length);
         data->file_path_buffer[desired_length] = '\0';
         nk_console_trigger_event(file, NK_CONSOLE_EVENT_CHANGED);
+        if (data->file_action) {
+            file->disabled = nk_true;
+        }
     }
 
     // Exit the file browser.
@@ -481,6 +501,9 @@ static void nk_console_file_button_file_onclick(nk_console* button, void* user_d
         NK_MEMCPY(data->file_path_buffer, data->directory, (nk_size)desired_length);
         data->file_path_buffer[desired_length] = '\0';
         nk_console_trigger_event(file, NK_CONSOLE_EVENT_CHANGED);
+        if (data->file_action) {
+            file->disabled = nk_true;
+        }
     }
     nk_console_navigate_back(file);
 }
@@ -814,6 +837,18 @@ NK_API nk_console* nk_console_dir(nk_console* parent, const char* label, char* d
 
     nk_console_file_data* data = (nk_console_file_data*)widget->data;
     data->select_directory = nk_true;
+
+    return widget;
+}
+
+NK_API nk_console* nk_console_file_action(nk_console* parent, const char* label, char* file_path_buffer, int file_path_buffer_size) {
+    nk_console* widget = nk_console_file(parent, label, file_path_buffer, file_path_buffer_size);
+    if (widget == NULL) {
+        return NULL;
+    }
+
+    nk_console_file_data* data = (nk_console_file_data*)widget->data;
+    data->file_action = nk_true;
 
     return widget;
 }

--- a/nuklear_console_file.h
+++ b/nuklear_console_file.h
@@ -75,6 +75,19 @@ NK_API nk_console* nk_console_dir(nk_console* parent, const char* label, char* d
 NK_API nk_console* nk_console_file_action(nk_console* parent, const char* label, char* file_path_buffer, int file_path_buffer_size);
 
 /**
+ * Creates a directory action widget that shows a single full-width button. The label is used as
+ * the button text before a directory is selected; afterwards the button shows the chosen directory.
+ *
+ * @param parent The parent widget.
+ * @param label The button label. For example: "Select a directory". Pass NULL for the default text.
+ * @param dir_buffer The buffer to store the directory path.
+ * @param dir_buffer_size The size of the buffer.
+ *
+ * @return The new directory action widget.
+ */
+NK_API nk_console* nk_console_dir_action(nk_console* parent, const char* label, char* dir_buffer, int dir_buffer_size);
+
+/**
  * Render callback to display the file widget.
  */
 NK_API struct nk_rect nk_console_file_render(nk_console* widget);
@@ -845,6 +858,18 @@ NK_API nk_console* nk_console_file_action(nk_console* parent, const char* label,
     nk_console_file_data* data = (nk_console_file_data*)widget->data;
     data->file_action = nk_true;
     widget->columns = 1;
+
+    return widget;
+}
+
+NK_API nk_console* nk_console_dir_action(nk_console* parent, const char* label, char* dir_buffer, int dir_buffer_size) {
+    nk_console* widget = nk_console_file_action(parent, label, dir_buffer, dir_buffer_size);
+    if (widget == NULL) {
+        return NULL;
+    }
+
+    nk_console_file_data* data = (nk_console_file_data*)widget->data;
+    data->select_directory = nk_true;
 
     return widget;
 }

--- a/nuklear_console_file.h
+++ b/nuklear_console_file.h
@@ -201,10 +201,16 @@ NK_API struct nk_rect nk_console_file_render(nk_console* console) {
     }
     nk_console_file_data* data = (nk_console_file_data*)console->data;
 
+    // In file_action mode, collapse to a single-column layout (no left label).
+    int orig_columns = console->columns;
+    if (data->file_action) {
+        console->columns = 1;
+    }
+
     nk_console_layout_widget(console);
 
-    // Display the label
-    if (console->label != NULL && console->label[0] != '\0') {
+    // Display the label (skipped in file_action mode — it becomes the button text instead).
+    if (!data->file_action && console->label != NULL && console->label[0] != '\0') {
         if (!nk_console_is_active_widget(console)) {
             nk_widget_disable_begin(console->ctx);
         }
@@ -220,18 +226,21 @@ NK_API struct nk_rect nk_console_file_render(nk_console* console) {
     }
 
     // Display the mocked button
-    int swap_columns = console->columns;
-    const char* swap_label = console->label;
+    const char* orig_label = console->label;
     console->columns = 0;
     if (data->file_path_buffer != NULL && data->file_path_buffer[0] != '\0') {
         console->label = nk_console_file_basename(data->file_path_buffer);
+    }
+    else if (data->file_action && orig_label != NULL && orig_label[0] != '\0') {
+        // In file_action mode, use the widget label as the button text.
+        console->label = orig_label;
     }
     else {
         console->label = data->select_directory ? "[Select Directory]" : "[Select a File]";
     }
     struct nk_rect widget_bounds = nk_console_button_render(console);
-    console->columns = swap_columns;
-    console->label = swap_label;
+    console->columns = orig_columns;
+    console->label = orig_label;
 
     return widget_bounds;
 }

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -105,12 +105,6 @@ int main() {
     nk_console* file = nk_console_file(console, "File", file_path_buffer, file_path_buffer_size);
     assert(file != NULL);
 
-    // nk_console_file_action()
-    static char file_action_buffer[256] = "";
-    nk_console* file_action = nk_console_file_action(console, "Action File", file_action_buffer, 256);
-    assert(file_action != NULL);
-    assert(file_action->disabled == nk_false);
-
     // nk_console_image()
     pntr_image* image_value = pntr_load_image("resources/image.png");
     assert(image_value != NULL);

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -105,6 +105,12 @@ int main() {
     nk_console* file = nk_console_file(console, "File", file_path_buffer, file_path_buffer_size);
     assert(file != NULL);
 
+    // nk_console_file_action()
+    static char file_action_buffer[256] = "";
+    nk_console* file_action = nk_console_file_action(console, "Action File", file_action_buffer, 256);
+    assert(file_action != NULL);
+    assert(file_action->disabled == nk_false);
+
     // nk_console_image()
     pntr_image* image_value = pntr_load_image("resources/image.png");
     assert(image_value != NULL);


### PR DESCRIPTION
Adds `nk_console_file_action()` — a file widget variant that shows a single button and disables itself after the user selects a file, preventing re-selection.

Closes #168