### PR TITLE
Make nuklear_gamepad an optional dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,28 +6,31 @@ project(nuklear_console
     LANGUAGES C
 )
 
-# nuklear_gamepad
-# TODO: Move the nuklear_gamepad definition elsewhere?
-find_package(nuklear_gamepad QUIET)
-if (NOT nuklear_gamepad_FOUND)
-    include(FetchContent)
-    FetchContent_Declare(
-        nuklear_gamepad
-        GIT_REPOSITORY https://github.com/RobLoach/nuklear_gamepad.git
-        GIT_TAG 82056c3
-    )
-    FetchContent_GetProperties(nuklear_gamepad)
-    if (NOT nuklear_gamepad_POPULATED)
-        set(FETCHCONTENT_QUIET NO)
-        FetchContent_Populate(nuklear_gamepad)
-        add_subdirectory(${nuklear_gamepad_SOURCE_DIR} ${nuklear_gamepad_BINARY_DIR})
-    endif()
-endif()
+option(NUKLEAR_CONSOLE_GAMEPAD "Enable nuklear_gamepad gamepad input support" ON)
 
 # nuklear_console
 add_library(nuklear_console INTERFACE)
 target_include_directories(nuklear_console INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(nuklear_console INTERFACE nuklear_gamepad)
+
+if (NUKLEAR_CONSOLE_GAMEPAD)
+    find_package(nuklear_gamepad QUIET)
+    if (NOT nuklear_gamepad_FOUND)
+        include(FetchContent)
+        FetchContent_Declare(
+            nuklear_gamepad
+            GIT_REPOSITORY https://github.com/RobLoach/nuklear_gamepad.git
+            GIT_TAG 82056c3
+        )
+        FetchContent_GetProperties(nuklear_gamepad)
+        if (NOT nuklear_gamepad_POPULATED)
+            set(FETCHCONTENT_QUIET NO)
+            FetchContent_Populate(nuklear_gamepad)
+            add_subdirectory(${nuklear_gamepad_SOURCE_DIR} ${nuklear_gamepad_BINARY_DIR})
+        endif()
+    endif()
+    target_link_libraries(nuklear_console INTERFACE nuklear_gamepad)
+    target_compile_definitions(nuklear_console INTERFACE NK_CONSOLE_GAMEPAD)
+endif()
 
 # Options
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -3,6 +3,7 @@
 
 #include "../../vendor/Nuklear/demo/common/style.c"
 
+// To build without nuklear_gamepad, remove the following two lines:
 #define NK_GAMEPAD_IMPLEMENTATION
 #include "../../vendor/nuklear_gamepad/nuklear_gamepad.h"
 

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -1,35 +1,7 @@
 #ifndef NK_CONSOLE_H__
 #define NK_CONSOLE_H__
 
-// Auto-detect nuklear_gamepad if already included before this header.
-#if defined(NUKLEAR_GAMEPAD_H__) && !defined(NK_CONSOLE_NO_GAMEPAD) && !defined(NK_CONSOLE_GAMEPAD)
-#    define NK_CONSOLE_GAMEPAD
-#endif
-
-#ifndef NK_CONSOLE_GAMEPAD
-// Stub types so nuklear_console.h compiles without nuklear_gamepad.h.
-// To enable gamepad support: include nuklear_gamepad.h BEFORE nuklear_console.h.
-struct nk_gamepads;
-
-enum nk_gamepad_button {
-    NK_GAMEPAD_BUTTON_INVALID = -1, NK_GAMEPAD_BUTTON_FIRST = 0,
-    NK_GAMEPAD_BUTTON_UP = 0, NK_GAMEPAD_BUTTON_DOWN = 1,
-    NK_GAMEPAD_BUTTON_LEFT = 2, NK_GAMEPAD_BUTTON_RIGHT = 3,
-    NK_GAMEPAD_BUTTON_A = 4, NK_GAMEPAD_BUTTON_B = 5,
-    NK_GAMEPAD_BUTTON_X = 6, NK_GAMEPAD_BUTTON_Y = 7,
-    NK_GAMEPAD_BUTTON_LB = 8, NK_GAMEPAD_BUTTON_RB = 9,
-    NK_GAMEPAD_BUTTON_BACK = 10, NK_GAMEPAD_BUTTON_START = 11,
-    NK_GAMEPAD_BUTTON_GUIDE = 12, NK_GAMEPAD_BUTTON_LAST = 13
-};
-
-enum nk_gamepad_axis {
-    NK_GAMEPAD_AXIS_INVALID = -1, NK_GAMEPAD_AXIS_FIRST = 0,
-    NK_GAMEPAD_AXIS_LEFT_X = 0, NK_GAMEPAD_AXIS_LEFT_Y = 1,
-    NK_GAMEPAD_AXIS_RIGHT_X = 2, NK_GAMEPAD_AXIS_RIGHT_Y = 3,
-    NK_GAMEPAD_AXIS_LEFT_TRIGGER = 4, NK_GAMEPAD_AXIS_RIGHT_TRIGGER = 5,
-    NK_GAMEPAD_AXIS_LAST = 6
-};
-#endif /* !NK_CONSOLE_GAMEPAD */
+#include "nuklear_console_gamepad_stub.h"
 
 struct nk_console;
 struct nk_console_event_handler;
@@ -516,6 +488,7 @@ extern "C" {
 #include "nuklear_console_color.h"
 #include "nuklear_console_combobox.h"
 #include "nuklear_console_file.h"
+#include "nuklear_console_gamepad_stub.h"
 #include "nuklear_console_file_system.h"
 #include "nuklear_console_image.h"
 #include "nuklear_console_input.h"
@@ -969,18 +942,6 @@ static nk_bool nk_console_axis_tick(struct nk_console_axis_channel* ch, float st
     }
     return nk_false;
 }
-
-#ifndef NK_CONSOLE_GAMEPAD
-static float nk_gamepad_get_axis(struct nk_gamepads* g, int n, enum nk_gamepad_axis a) {
-    (void)g; (void)n; (void)a; return 0.0f;
-}
-static nk_bool nk_gamepad_is_button_released(struct nk_gamepads* g, int n, enum nk_gamepad_button b) {
-    (void)g; (void)n; (void)b; return nk_false;
-}
-static nk_bool nk_gamepad_is_button_down(struct nk_gamepads* g, int n, enum nk_gamepad_button b) {
-    (void)g; (void)n; (void)b; return nk_false;
-}
-#endif /* !NK_CONSOLE_GAMEPAD */
 
 /**
  * Checks all the gamepad input states, and combines all the gamepad axis into one.

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -1,6 +1,36 @@
 #ifndef NK_CONSOLE_H__
 #define NK_CONSOLE_H__
 
+// Auto-detect nuklear_gamepad if already included before this header.
+#if defined(NUKLEAR_GAMEPAD_H__) && !defined(NK_CONSOLE_NO_GAMEPAD) && !defined(NK_CONSOLE_GAMEPAD)
+#    define NK_CONSOLE_GAMEPAD
+#endif
+
+#ifndef NK_CONSOLE_GAMEPAD
+// Stub types so nuklear_console.h compiles without nuklear_gamepad.h.
+// To enable gamepad support: include nuklear_gamepad.h BEFORE nuklear_console.h.
+struct nk_gamepads;
+
+enum nk_gamepad_button {
+    NK_GAMEPAD_BUTTON_INVALID = -1, NK_GAMEPAD_BUTTON_FIRST = 0,
+    NK_GAMEPAD_BUTTON_UP = 0, NK_GAMEPAD_BUTTON_DOWN = 1,
+    NK_GAMEPAD_BUTTON_LEFT = 2, NK_GAMEPAD_BUTTON_RIGHT = 3,
+    NK_GAMEPAD_BUTTON_A = 4, NK_GAMEPAD_BUTTON_B = 5,
+    NK_GAMEPAD_BUTTON_X = 6, NK_GAMEPAD_BUTTON_Y = 7,
+    NK_GAMEPAD_BUTTON_LB = 8, NK_GAMEPAD_BUTTON_RB = 9,
+    NK_GAMEPAD_BUTTON_BACK = 10, NK_GAMEPAD_BUTTON_START = 11,
+    NK_GAMEPAD_BUTTON_GUIDE = 12, NK_GAMEPAD_BUTTON_LAST = 13
+};
+
+enum nk_gamepad_axis {
+    NK_GAMEPAD_AXIS_INVALID = -1, NK_GAMEPAD_AXIS_FIRST = 0,
+    NK_GAMEPAD_AXIS_LEFT_X = 0, NK_GAMEPAD_AXIS_LEFT_Y = 1,
+    NK_GAMEPAD_AXIS_RIGHT_X = 2, NK_GAMEPAD_AXIS_RIGHT_Y = 3,
+    NK_GAMEPAD_AXIS_LEFT_TRIGGER = 4, NK_GAMEPAD_AXIS_RIGHT_TRIGGER = 5,
+    NK_GAMEPAD_AXIS_LAST = 6
+};
+#endif /* !NK_CONSOLE_GAMEPAD */
+
 struct nk_console;
 struct nk_console_event_handler;
 
@@ -939,6 +969,18 @@ static nk_bool nk_console_axis_tick(struct nk_console_axis_channel* ch, float st
     }
     return nk_false;
 }
+
+#ifndef NK_CONSOLE_GAMEPAD
+static float nk_gamepad_get_axis(struct nk_gamepads* g, int n, enum nk_gamepad_axis a) {
+    (void)g; (void)n; (void)a; return 0.0f;
+}
+static nk_bool nk_gamepad_is_button_released(struct nk_gamepads* g, int n, enum nk_gamepad_button b) {
+    (void)g; (void)n; (void)b; return nk_false;
+}
+static nk_bool nk_gamepad_is_button_down(struct nk_gamepads* g, int n, enum nk_gamepad_button b) {
+    (void)g; (void)n; (void)b; return nk_false;
+}
+#endif /* !NK_CONSOLE_GAMEPAD */
 
 /**
  * Checks all the gamepad input states, and combines all the gamepad axis into one.

--- a/nuklear_console_gamepad_stub.h
+++ b/nuklear_console_gamepad_stub.h
@@ -1,0 +1,85 @@
+/**
+ * @file Provides the ability to stub out the use of nuklear_gamepad.
+ *
+ * Usually in order to use nuklear_console, you would include nuklear_gamepad.h prior to using nuklear_console.h. This stub allows skipping nuklear_gamepad, disabling gamepad support entirely.
+ *
+ * While using nuklear_gamepad is recommended, you are able to use nuklear_console without it.
+ *
+ * @see https://github.com/robloach/nuklear_gamepad
+ */
+
+#ifndef NK_CONSOLE_GAMEPAD_STUB_H__
+#define NK_CONSOLE_GAMEPAD_STUB_H__
+
+// Auto-detect nuklear_gamepad is included. Use it if it is, place a stub otherwise.
+#if defined(NUKLEAR_GAMEPAD_H__) && !defined(NK_CONSOLE_NO_GAMEPAD) && !defined(NK_CONSOLE_GAMEPAD)
+#define NK_CONSOLE_GAMEPAD
+#endif
+
+#ifndef NK_CONSOLE_GAMEPAD
+/**
+ * Stubbed nk_gamepads for mocked usage.
+ */
+typedef struct nk_gamepads {
+    int num;
+} nk_gamepads;
+
+enum nk_gamepad_button {
+    NK_GAMEPAD_BUTTON_INVALID = -1, NK_GAMEPAD_BUTTON_FIRST = 0,
+    NK_GAMEPAD_BUTTON_UP = 0, NK_GAMEPAD_BUTTON_DOWN = 1,
+    NK_GAMEPAD_BUTTON_LEFT = 2, NK_GAMEPAD_BUTTON_RIGHT = 3,
+    NK_GAMEPAD_BUTTON_A = 4, NK_GAMEPAD_BUTTON_B = 5,
+    NK_GAMEPAD_BUTTON_X = 6, NK_GAMEPAD_BUTTON_Y = 7,
+    NK_GAMEPAD_BUTTON_LB = 8, NK_GAMEPAD_BUTTON_RB = 9,
+    NK_GAMEPAD_BUTTON_BACK = 10, NK_GAMEPAD_BUTTON_START = 11,
+    NK_GAMEPAD_BUTTON_GUIDE = 12, NK_GAMEPAD_BUTTON_LAST = 13
+};
+
+enum nk_gamepad_axis {
+    NK_GAMEPAD_AXIS_INVALID = -1, NK_GAMEPAD_AXIS_FIRST = 0,
+    NK_GAMEPAD_AXIS_LEFT_X = 0, NK_GAMEPAD_AXIS_LEFT_Y = 1,
+    NK_GAMEPAD_AXIS_RIGHT_X = 2, NK_GAMEPAD_AXIS_RIGHT_Y = 3,
+    NK_GAMEPAD_AXIS_LEFT_TRIGGER = 4, NK_GAMEPAD_AXIS_RIGHT_TRIGGER = 5,
+    NK_GAMEPAD_AXIS_LAST = 6
+};
+
+#endif /* !NK_CONSOLE_GAMEPAD */
+
+#endif /* !NK_CONSOLE_GAMEPAD_STUB_H__ */
+
+#if defined(NK_CONSOLE_IMPLEMENTATION) && !defined(NK_CONSOLE_GAMEPAD) && !defined(NK_CONSOLE_GAMEPAD_STUB_IMPLEMENTATION_ONCE)
+#define NK_CONSOLE_GAMEPAD_STUB_IMPLEMENTATION_ONCE
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+static float nk_gamepad_get_axis(struct nk_gamepads* g, int n, enum nk_gamepad_axis a) {
+    NK_UNUSED(g); NK_UNUSED(n); NK_UNUSED(a); return 0.0f;
+}
+
+static nk_bool nk_gamepad_is_button_released(struct nk_gamepads* g, int n, enum nk_gamepad_button b) {
+    NK_UNUSED(g); NK_UNUSED(n); NK_UNUSED(b); return nk_false;
+}
+
+static nk_bool nk_gamepad_is_button_down(struct nk_gamepads* g, int n, enum nk_gamepad_button b) {
+    NK_UNUSED(g); NK_UNUSED(n); NK_UNUSED(b); return nk_false;
+}
+
+static nk_bool nk_gamepad_init(struct nk_gamepads* gamepads, struct nk_context* ctx, void* user_data) {
+    NK_UNUSED(gamepads); NK_UNUSED(ctx); NK_UNUSED(user_data); return nk_true;
+}
+
+static void nk_gamepad_free(struct nk_gamepads* gamepads) {
+    NK_UNUSED(gamepads);
+}
+
+static void nk_gamepad_update(struct nk_gamepads* gamepads) {
+    NK_UNUSED(gamepads);
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/nuklear_console_input.h
+++ b/nuklear_console_input.h
@@ -67,6 +67,20 @@ NK_API enum nk_gamepad_button nk_console_input_get_default(nk_console* widget);
 extern "C" {
 #endif
 
+#ifndef NK_CONSOLE_GAMEPAD
+static const char* nk_gamepad_button_name(struct nk_gamepads* g, enum nk_gamepad_button b) {
+    (void)g;
+    static const char* names[] = {
+        "Up","Down","Left","Right","A","B","X","Y","LB","RB","Back","Start","Guide"
+    };
+    if (b >= 0 && b < NK_GAMEPAD_BUTTON_LAST) return names[(int)b];
+    return NULL;
+}
+static nk_bool nk_gamepad_any_button_released(struct nk_gamepads* g, int n, int* on, enum nk_gamepad_button* ob) {
+    (void)g; (void)n; (void)on; (void)ob; return nk_false;
+}
+#endif /* !NK_CONSOLE_GAMEPAD */
+
 NK_API struct nk_rect nk_console_input_render(nk_console* console) {
     if (console == NULL || console->data == NULL) {
         return nk_rect(0, 0, 0, 0);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,10 +39,14 @@ add_executable(nuklear_console_test nuklear_console_test.c)
 target_compile_options(nuklear_console_test PRIVATE -Wall -Wextra -Wconversion -Wsign-conversion)
 target_link_libraries(nuklear_console_test PUBLIC
     nuklear_console
-    nuklear_gamepad
     pntr
     pntr_nuklear
 )
+if (NUKLEAR_CONSOLE_GAMEPAD)
+    target_link_libraries(nuklear_console_test PUBLIC nuklear_gamepad)
+else()
+    target_compile_definitions(nuklear_console_test PRIVATE NK_CONSOLE_NO_GAMEPAD)
+endif()
 
 # Copy the resources
 file(GLOB resources resources/*)

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -15,9 +15,11 @@
 #define NK_BUTTON_TRIGGER_ON_RELEASE
 #include "pntr_nuklear.h"
 
+#ifndef NK_CONSOLE_NO_GAMEPAD
 #define NK_GAMEPAD_NONE
 #define NK_GAMEPAD_IMPLEMENTATION
 #include "nuklear_gamepad.h"
+#endif
 
 #define NK_CONSOLE_IMPLEMENTATION
 #include "nuklear_console.h"
@@ -85,11 +87,13 @@ int main() {
     assert(console != NULL);
 
     // Gamepad
+    #ifndef NK_CONSOLE_NO_GAMEPAD
     {
         struct nk_gamepads gamepads;
         assert(nk_gamepad_init(&gamepads, ctx, NULL) == nk_true);
         nk_console_set_gamepads(console, &gamepads);
     }
+    #endif
 
     // nk_console_label()
     {


### PR DESCRIPTION
Adds a `NUKLEAR_CONSOLE_GAMEPAD` CMake option (default ON) to make nuklear_gamepad optional. When OFF, stub enums and no-op inline functions are injected so all widget code compiles unchanged with gamepad input silently disabled. Existing users see no change; new users can opt out by setting the option to OFF or by omitting nuklear_gamepad entirely.

Fixes #196