### PR TITLE
progress: Add nk_console_progress_update() for runtime value/max changes

### DIFF
--- a/nuklear_console_progress.h
+++ b/nuklear_console_progress.h
@@ -11,6 +11,7 @@ extern "C" {
 #endif
 
 NK_API nk_console* nk_console_progress(nk_console* parent, const char* text, nk_size* current, nk_size max);
+NK_API void nk_console_progress_update(nk_console* progress, const char* label, nk_size* current, nk_size max);
 NK_API struct nk_rect nk_console_progress_render(nk_console* console);
 
 #if defined(__cplusplus)
@@ -47,6 +48,21 @@ NK_API nk_console* nk_console_progress(nk_console* parent, const char* text, nk_
         *current = max;
     }
     return progress;
+}
+
+NK_API void nk_console_progress_update(nk_console* progress, const char* label, nk_size* current, nk_size max) {
+    if (!progress || !progress->data) return;
+    nk_console_progress_data* data = (nk_console_progress_data*)progress->data;
+
+    progress->label = label;
+    progress->label_length = nk_strlen(label);
+    progress->columns = label != NULL ? 2 : 1;
+    data->value_size = current;
+    data->max_size = max;
+
+    if (current != NULL && *current > max) {
+        *current = max;
+    }
 }
 
 NK_API struct nk_rect nk_console_progress_render(nk_console* console) {


### PR DESCRIPTION
Adds `nk_console_progress_update()` following the pattern of `nk_console_combobox_update()`, allowing callers to change the label, value pointer, and max at runtime — re-clamping the current value if it exceeds the new max. Fixes #193