### PR TITLE
Document missing NK_CONSOLE_* configuration macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,28 @@ void nk_console_check_up_down(nk_console* widget);
 
 ## Configuration
 
-Define | Description
------- | -----------
-`NK_BUTTON_TRIGGER_ON_RELEASE` | Required in order to ensure events are triggered in the correct order
-`NK_CONSOLE_KEY_BACK` | The `nk_keys` enumeration that will be used to go back in the menu heirarchy. Defaults to ESC.
-`NK_CONSOLE_DRAG_THRESHOLD` | The amount of threshold mouse movement needed to consider it a scroll
-`NK_CONSOLE_AXIS_DEADZONE` | The amount of movement the gamepad axis needs prior to moving the cursor
-`NK_CONSOLE_AXIS_REPEAT_INTERVAL` | When using the gamepad axis to move, how frequently the cursor will move
-`NK_CONSOLE_FILE_ADD_FILES` | The function callback used to enumerate files, see `nk_console_file_add_files_tinydir()`
+Define | Default | Description
+------ | ------- | -----------
+`NK_BUTTON_TRIGGER_ON_RELEASE` | *(unset)* | Required in order to ensure events are triggered in the correct order
+`NK_CONSOLE_KEY_BACK` | `NK_KEY_TEXT_RESET_MODE` | The `nk_keys` enumeration that will be used to go back in the menu hierarchy. Defaults to ESC.
+`NK_CONSOLE_DRAG_THRESHOLD` | `8.0f` | The amount of threshold mouse movement needed to consider it a scroll
+`NK_CONSOLE_AXIS_DEADZONE` | `0.22f` | The amount of movement the gamepad axis needs prior to moving the cursor
+`NK_CONSOLE_AXIS_REPEAT_INTERVAL` | `0.5f` | When using the gamepad axis to move, how frequently the cursor will move
+`NK_CONSOLE_MALLOC` | `nk_malloc` | Memory allocation function used internally
+`NK_CONSOLE_FREE` | `nk_mfree` | Memory free function used internally
+`NK_CONSOLE_IGNORE_BUTTON_TRIGGER_ON_RELEASE` | *(unset)* | Define to suppress the `NK_BUTTON_TRIGGER_ON_RELEASE` warning
+`NK_CONSOLE_FILE_PATH_MAX` | `PATH_MAX` / `4096` | Maximum file path length used by the file widget
+`NK_CONSOLE_FILE_ADD_FILES` | *(auto-detected)* | The function callback used to enumerate files; see `nk_console_file_add_files_tinydir()`
+`NK_CONSOLE_ENABLE_TINYDIR` | *(unset)* | Define to use tinydir for file enumeration
+`NK_CONSOLE_FILE_ADD_FILES_TINYDIR_H` | `"vendor/tinydir/tinydir.h"` | Path to the tinydir header when using the tinydir file backend
+`NK_CONSOLE_FILE_ADD_FILES_TINYDIR_SKIP` | *(unset)* | Define to skip the tinydir header include (provide your own include before)
+`NK_CONSOLE_INPUT_TIMER` | `6.0f` | Number of characters per second typed when holding a key in the text-input widget
+`NK_CONSOLE_KEY_TIMER` | `6.0f` | Number of characters per second typed when holding a key in the key-capture widget
+`NK_CONSOLE_TEXTEDIT_MASKED_LENGTH` | `8` | Number of `*` characters shown when the text-edit widget is in masked/password mode
+`NK_CONSOLE_TEXTEDIT_PREVIEW_LENGTH` | `10` | Maximum preview character count shown in a collapsed text-edit widget
+`NK_CONSOLE_MESSAGE_DURATION` | `4.0f` | Seconds a message widget is displayed before auto-dismissal
+`NK_CONSOLE_MESSAGE_SCROLL_SPEED` | `60.0f` | Pixels per second at which a long message scrolls horizontally
+`NK_CONSOLE_MESSAGE_SCROLL_PAUSE` | `1.5f` | Seconds to pause at the start and end of a scrolling message
 
 ## Development
 


### PR DESCRIPTION
Adds all undocumented NK_CONSOLE_* configuration macros to the README Configuration table, including defaults and descriptions. Fixes #206