### PR TITLE
Fix knob_data docstring copy-paste

### DIFF
--- a/nuklear_console_knob.h
+++ b/nuklear_console_knob.h
@@ -4,7 +4,7 @@
 #include "nuklear_console_property.h"
 
 /**
- * Data for Property and Slider widgets.
+ * Data for Knob widgets.
  */
 typedef struct nk_console_knob_data {
     nk_console_property_data property; /* Inherited from property */


### PR DESCRIPTION
Updates the nk_console_knob_data struct comment from "Data for Property and Slider widgets." to "Data for Knob widgets.". Fixes #209