### PR TITLE
Scroll to active widget on set_active_parent

### DIFF
--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -651,8 +651,8 @@ NK_API void nk_console_set_active_parent(nk_console* new_parent) {
     data->active_parent = new_parent;
 
     // Scroll to the active widget in the new parent, falling back to the top.
-    if (data->active_widget != NULL) {
-        data->scroll_to_widget = data->active_widget;
+    if (new_parent->activeWidget != NULL) {
+        data->scroll_to_widget = new_parent->activeWidget;
     } else {
         nk_window_set_scroll(top->ctx, 0, 0);
     }

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -647,12 +647,15 @@ NK_API void nk_console_set_active_parent(nk_console* new_parent) {
         return;
     }
 
-    // When switching parents, bring the window scroll to the top to that the window doesn't appear empty.
-    // TODO: Fix the scroll on the new window, since it may not be centered on the active widget.
-    nk_window_set_scroll(top->ctx, 0, 0);
-
     nk_console_top_data* data = (nk_console_top_data*)top->data;
     data->active_parent = new_parent;
+
+    // Scroll to the active widget in the new parent, falling back to the top.
+    if (data->active_widget != NULL) {
+        data->scroll_to_widget = data->active_widget;
+    } else {
+        nk_window_set_scroll(top->ctx, 0, 0);
+    }
 }
 
 /**


### PR DESCRIPTION
In nk_console_set_active_parent, instead of always resetting scroll to (0,0), set scroll_to_widget = data->active_widget so the next render pass scrolls to the focused widget. Falls back to scroll reset when no active widget is set. Fixes #210