### PR TITLE
Add Doxygen comments to NK_API declarations

### DIFF
--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -181,43 +181,77 @@ typedef struct nk_console_top_data {
 extern "C" {
 #endif
 
-// Console
+/** @defgroup console Console lifecycle */
+/** Initialize a top-level console for the given Nuklear context. @return The root console widget. */
 NK_API nk_console* nk_console_init(struct nk_context* context);
+/** Free the console and all its children. */
 NK_API void nk_console_free(nk_console* console);
+/** Render the console inside the current Nuklear window. */
 NK_API void nk_console_render(nk_console* console);
+/** Render the console inside a new Nuklear window. @return The bounding rect of the rendered window. */
 NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* title, struct nk_rect bounds, nk_uint flags);
 
-// Utilities
+/** @defgroup utilities Widget utilities */
+/** Return the top-level console that owns @p widget. */
 NK_API nk_console* nk_console_get_top(nk_console* widget);
+/** Return the zero-based index of @p widget among its siblings. */
 NK_API int nk_console_get_widget_index(nk_console* widget);
+/** Draw the tooltip for the currently active widget, if any. */
 NK_API void nk_console_check_tooltip(nk_console* console);
+/** Handle keyboard/gamepad up and down navigation for @p widget. */
 NK_API void nk_console_check_up_down(nk_console* widget);
+/** Return nk_true if @p widget is the currently focused widget. */
 NK_API nk_bool nk_console_is_active_widget(nk_console* widget);
+/** Return the currently active parent (the visible menu level). */
 NK_API nk_console* nk_console_active_parent(nk_console* console);
+/** Set the active parent, switching the visible menu level. */
 NK_API void nk_console_set_active_parent(nk_console* new_parent);
+/** Set the focused widget within the active parent. */
 NK_API void nk_console_set_active_widget(nk_console* widget);
+/** Return the currently focused widget, or NULL if none. */
 NK_API nk_console* nk_console_get_active_widget(nk_console* widget);
+/** Allocate memory using the console's allocator (compatible with nk_allocator). */
 NK_API void* nk_console_malloc(nk_handle unused, void* old, nk_size size);
+/** Free memory using the console's allocator (compatible with nk_allocator). */
 NK_API void nk_console_mfree(nk_handle unused, void* ptr);
+/** Return nk_true if @p button was just pressed this frame (rising edge). */
 NK_API nk_bool nk_console_button_pushed(nk_console* console, int button);
+/** Return nk_true if @p button is currently held down. */
 NK_API nk_bool nk_console_button_down(nk_console* console, int button);
+/** Attach a nk_gamepads context to the console for gamepad input. */
 NK_API void nk_console_set_gamepads(nk_console* console, struct nk_gamepads* gamepads);
+/** Return the nk_gamepads context attached to the console. */
 NK_API struct nk_gamepads* nk_console_get_gamepads(nk_console* console);
+/** Set the number of gamepads polled each frame. */
 NK_API void nk_console_set_gamepad_num(nk_console* console, int num);
+/** Return the number of gamepads polled each frame. */
 NK_API int nk_console_get_gamepad_num(nk_console* console);
+/** Set the tooltip string shown when @p widget is focused. */
 NK_API void nk_console_set_tooltip(nk_console* widget, const char* tooltip);
+/** Replace the label of @p widget; pass -1 for @p label_length to auto-detect. */
 NK_API void nk_console_set_label(nk_console* widget, const char* label, int label_length);
+/** Return the current label of @p widget. */
 NK_API const char* nk_console_get_label(nk_console* widget);
+/** Destroy and free all child widgets of @p console. */
 NK_API void nk_console_free_children(nk_console* console);
+/** Emit the Nuklear row layout for @p widget (called internally before rendering). */
 NK_API void nk_console_layout_widget(nk_console* widget);
+/** Append @p child as a child of @p parent. */
 NK_API void nk_console_add_child(nk_console* parent, nk_console* child);
+/** Override the row height of @p widget in pixels. */
 NK_API void nk_console_set_height(nk_console* widget, int height);
+/** Return the row height of @p widget in pixels. */
 NK_API int nk_console_height(nk_console* widget);
+/** Return nk_true if @p widget can receive focus (is selectable). */
 NK_API nk_bool nk_console_selectable(nk_console* widget);
 
+/** Fire all handlers registered for @p type on @p widget. @return nk_true if any handler ran. */
 NK_API nk_bool nk_console_trigger_event(nk_console* widget, nk_console_event_type type);
+/** Register a simple callback for @p type on @p widget (no user data or destructor). */
 NK_API void nk_console_add_event(nk_console* widget, nk_console_event_type type, nk_console_event callback);
+/** Register a callback with user data and an optional destructor for @p type on @p widget. */
 NK_API void nk_console_add_event_handler(nk_console* widget, nk_console_event_type type, nk_console_event callback, void* user_data, nk_console_event destructor);
+/** Unregister and free a specific event handler from @p widget. */
 NK_API void nk_console_event_handler_destroy(nk_console* widget, nk_console_event_handler* handler);
 
 // Backwards compatibility

--- a/nuklear_console_button.h
+++ b/nuklear_console_button.h
@@ -10,16 +10,25 @@ typedef struct nk_console_button_data {
 extern "C" {
 #endif
 
+/** Add a button widget to @p parent. @return The new button widget. */
 NK_API nk_console* nk_console_button(nk_console* parent, const char* text);
+/** Render the button widget. @return The bounding rect. */
 NK_API struct nk_rect nk_console_button_render(nk_console* console);
+/** Navigate back to the parent menu; suitable as an NK_CONSOLE_EVENT_CLICKED callback. */
 NK_API void nk_console_button_back(nk_console* button, void* user_data);
+/** Add a button that fires @p onclick when clicked. @return The new button widget. */
 NK_API nk_console* nk_console_button_onclick(nk_console* parent, const char* text, nk_console_event onclick);
+/** Add a button with a full event handler (user data + destructor). @return The new button widget. */
 NK_API nk_console* nk_console_button_onclick_handler(nk_console* parent, const char* text, nk_console_event callback, void* data, nk_console_event destructor);
 
+/** Return the symbol type shown on the left side of @p button. */
 NK_API enum nk_symbol_type nk_console_button_get_symbol(nk_console* button);
+/** Set the symbol shown on the left side of @p button. */
 NK_API void nk_console_button_set_symbol(nk_console* button, enum nk_symbol_type symbol);
 
+/** Set an image to display on the left side of @p button. */
 NK_API void nk_console_button_set_image(nk_console* button, struct nk_image image);
+/** Return the image displayed on the left side of @p button. */
 NK_API struct nk_image nk_console_button_get_image(nk_console* button);
 
 #if defined(__cplusplus)

--- a/nuklear_console_checkbox.h
+++ b/nuklear_console_checkbox.h
@@ -9,7 +9,9 @@ typedef struct nk_console_checkbox_data {
 extern "C" {
 #endif
 
+/** Add a checkbox widget bound to @p active. @return The new checkbox widget. */
 NK_API nk_console* nk_console_checkbox(nk_console* parent, const char* text, nk_bool* active);
+/** Render the checkbox widget. @return The bounding rect. */
 NK_API struct nk_rect nk_console_checkbox_render(nk_console* console);
 
 #if defined(__cplusplus)

--- a/nuklear_console_combobox.h
+++ b/nuklear_console_combobox.h
@@ -17,10 +17,15 @@ typedef struct nk_console_combobox_data {
 extern "C" {
 #endif
 
+/** Add a combobox widget with pipe-separated items. @return The new combobox widget. */
 NK_API nk_console* nk_console_combobox(nk_console* parent, const char* label, const char* items_separated_by_separator, int separator, int* selected);
+/** Render the combobox widget. @return The bounding rect. */
 NK_API struct nk_rect nk_console_combobox_render(nk_console* console);
+/** Internal: handle a click on a combobox option button. */
 NK_API void nk_console_combobox_button_click(nk_console* button, void* user_data);
+/** Internal: handle a click on the combobox's main (label) button. */
 NK_API void nk_console_combobox_button_main_click(nk_console* button, void* user_data);
+/** Replace the items and selected pointer on an existing combobox widget. */
 NK_API void nk_console_combobox_update(nk_console* combobox, const char* label, const char* items_separated_by_separator, int separator, int* selected);
 
 #if defined(__cplusplus)

--- a/nuklear_console_input.h
+++ b/nuklear_console_input.h
@@ -33,6 +33,7 @@ extern "C" {
  * @return The new input widget.
  */
 NK_API nk_console* nk_console_input(nk_console* parent, const char* label, int gamepad_number, int* out_gamepad_number, enum nk_gamepad_button* out_gamepad_button);
+/** Render the input-capture widget. @return The bounding rect. */
 NK_API struct nk_rect nk_console_input_render(nk_console* widget);
 
 /**

--- a/nuklear_console_label.h
+++ b/nuklear_console_label.h
@@ -5,7 +5,9 @@
 extern "C" {
 #endif
 
+/** Add a non-interactive text label to @p parent. @return The new label widget. */
 NK_API nk_console* nk_console_label(nk_console* parent, const char* text);
+/** Render the label widget. @return The bounding rect. */
 NK_API struct nk_rect nk_console_label_render(nk_console* widget);
 
 #if defined(__cplusplus)

--- a/nuklear_console_progress.h
+++ b/nuklear_console_progress.h
@@ -10,8 +10,11 @@ typedef struct nk_console_progress_data {
 extern "C" {
 #endif
 
+/** Add a progress bar widget displaying @p current out of @p max. @return The new widget. */
 NK_API nk_console* nk_console_progress(nk_console* parent, const char* text, nk_size* current, nk_size max);
+/** Update the value and label of an existing progress bar widget. */
 NK_API void nk_console_progress_update(nk_console* progress, const char* label, nk_size* current, nk_size max);
+/** Render the progress bar widget. @return The bounding rect. */
 NK_API struct nk_rect nk_console_progress_render(nk_console* console);
 
 #if defined(__cplusplus)

--- a/nuklear_console_property.h
+++ b/nuklear_console_property.h
@@ -20,10 +20,15 @@ typedef struct nk_console_property_data {
 extern "C" {
 #endif
 
+/** Add an integer property widget (editable with left/right input). @return The new widget. */
 NK_API nk_console* nk_console_property_int(nk_console* parent, const char* label, int min, int* val, int max, int step, float inc_per_pixel);
+/** Add a float property widget (editable with left/right input). @return The new widget. */
 NK_API nk_console* nk_console_property_float(nk_console* parent, const char* label, float min, float* val, float max, float step, float inc_per_pixel);
+/** Add an integer slider widget (no text input). @return The new widget. */
 NK_API nk_console* nk_console_slider_int(nk_console* parent, const char* label, int min, int* val, int max, int step);
+/** Add a float slider widget (no text input). @return The new widget. */
 NK_API nk_console* nk_console_slider_float(nk_console* parent, const char* label, float min, float* val, float max, float step);
+/** Render the property/slider widget. @return The bounding rect. */
 NK_API struct nk_rect nk_console_property_render(nk_console* console);
 
 #if defined(__cplusplus)


### PR DESCRIPTION
Adds one-line Doxygen doc comments to all previously undocumented NK_API declarations in nuklear_console.h and the major widget headers (button, checkbox, combobox, label, progress, property, input). Fixes #212