### PR TITLE
Fix navigate back skipping row widgets

### DIFF
--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -546,6 +546,45 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
       calc->tooltip = "Demo rows and grids!";
     }
 
+    // Button within a row that owns a bunch of children.
+    // Verifies navigate back skips the row container and lands correctly (#227).
+    struct nk_console* row_submenu = nk_console_button(console, "Row Submenu");
+    {
+        nk_console_label(row_submenu, "Each button in the row below has its own children.");
+        nk_console_label(row_submenu, "Open one, then press Back to return to the row.");
+
+        struct nk_console* row = nk_console_row_begin(row_submenu);
+
+        // First button in the row, with a bunch of children.
+        struct nk_console* tools = nk_console_button(row, "Tools");
+        {
+            nk_console_label(tools, "Tools (children of a button inside a row):");
+            nk_console_button(tools, "Hammer");
+            nk_console_button(tools, "Wrench");
+            nk_console_button(tools, "Screwdriver");
+            nk_console_button(tools, "Pliers");
+            nk_console_button(tools, "Saw");
+            nk_console_button_onclick(tools, "Back", &nk_console_button_back);
+        }
+
+        // Second button in the row, also with a bunch of children.
+        struct nk_console* colors = nk_console_button(row, "Colors");
+        {
+            nk_console_label(colors, "Colors (children of a button inside a row):");
+            nk_console_button(colors, "Red");
+            nk_console_button(colors, "Green");
+            nk_console_button(colors, "Blue");
+            nk_console_button(colors, "Yellow");
+            nk_console_button_onclick(colors, "Back", &nk_console_button_back);
+        }
+
+        nk_console_row_end(row);
+
+        nk_console_button_onclick(row_submenu, "Back", &nk_console_button_back);
+
+        row_submenu->tooltip = "A button within a row that has children (tests navigate back).";
+    }
+
     // Open Path
     struct nk_console* open_path = nk_console_button(console, "Open Path");
     {

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -1463,14 +1463,22 @@ NK_API void nk_console_navigate_back(nk_console* leaving_parent) {
         return;
     }
 
-    // If leaving_parent is a row or tree (non-navigable containers), skip up to
-    // the first ancestor that can act as an active parent.
+    // Traverse up until we're not on a row or tree. Rows and trees can't act as
+    // active parents (their children render through the container, not directly),
+    // so keep skipping them and let target track the direct child of the
+    // destination, so focus lands on a navigable widget.
     nk_console* target = leaving_parent;
     while (target != top && (target->type == NK_CONSOLE_ROW || target->type == NK_CONSOLE_TREE)) {
         target = (target->parent != NULL) ? target->parent : top;
     }
 
+    // Verify the destination, and find the target.
     nk_console* destination = (target->parent != NULL) ? target->parent : top;
+    while (destination != top && (destination->type == NK_CONSOLE_ROW || destination->type == NK_CONSOLE_TREE)) {
+        target = destination;
+        destination = (destination->parent != NULL) ? destination->parent : top;
+    }
+
     nk_console_set_active_parent(destination);
     nk_console_set_active_widget(target);
     if (data != NULL) {

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -1463,10 +1463,10 @@ NK_API void nk_console_navigate_back(nk_console* leaving_parent) {
         return;
     }
 
-    // If leaving_parent is a row (or any non-navigable widget), skip up to its
-    // parent so we don't land on a widget that cannot act as an active parent.
+    // If leaving_parent is a row or tree (non-navigable containers), skip up to
+    // the first ancestor that can act as an active parent.
     nk_console* target = leaving_parent;
-    while (target != top && target->type == NK_CONSOLE_ROW) {
+    while (target != top && (target->type == NK_CONSOLE_ROW || target->type == NK_CONSOLE_TREE)) {
         target = (target->parent != NULL) ? target->parent : top;
     }
 

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -1462,11 +1462,19 @@ NK_API void nk_console_navigate_back(nk_console* leaving_parent) {
         data->input_processed = nk_true;
         return;
     }
-    nk_console* destination = (leaving_parent->parent != NULL) ? leaving_parent->parent : top;
+
+    // If leaving_parent is a row (or any non-navigable widget), skip up to its
+    // parent so we don't land on a widget that cannot act as an active parent.
+    nk_console* target = leaving_parent;
+    while (target != top && target->type == NK_CONSOLE_ROW) {
+        target = (target->parent != NULL) ? target->parent : top;
+    }
+
+    nk_console* destination = (target->parent != NULL) ? target->parent : top;
     nk_console_set_active_parent(destination);
-    nk_console_set_active_widget(leaving_parent);
+    nk_console_set_active_widget(target);
     if (data != NULL) {
-        data->scroll_to_widget = leaving_parent;
+        data->scroll_to_widget = target;
         data->input_processed = nk_true;
     }
     nk_console_trigger_event(leaving_parent, NK_CONSOLE_EVENT_BACK);

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -351,6 +351,27 @@ int main() {
         assert(back_count == 1);
         assert(nk_console_active_parent(nav) == nav);
 
+        // Navigate back from a widget inside a row skips the row and goes to
+        // the row's parent, preventing a crash (#227).
+        {
+            nk_console* menu = nk_console_button(nav, "Menu");
+            nk_console* row = nk_console_row_begin(menu);
+            nk_console* btn_in_row = nk_console_button(row, "Row Button");
+            nk_console_row_end(row);
+            assert(btn_in_row->parent == row);
+            assert(row->type == NK_CONSOLE_ROW);
+
+            // Navigate into menu so it becomes the active parent.
+            nk_console_set_active_parent(menu);
+            assert(nk_console_active_parent(nav) == menu);
+
+            // Simulate navigating back when the active widget is inside a row.
+            // nk_console_navigate_back(btn_in_row->parent) == navigate_back(row).
+            // The row should be skipped; active parent should become nav (row->parent->parent).
+            nk_console_navigate_back(row);
+            assert(nk_console_active_parent(nav) == nav);
+        }
+
         nk_console_free(nav);
     }
     nk_end(ctx);

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -372,6 +372,30 @@ int main() {
             assert(nk_console_active_parent(nav) == nav);
         }
 
+        // Navigate back from a button *inside* a row that has its own children:
+        // opening the button then pressing Back must land on the row's parent
+        // page (not the row itself, which can't be an active parent) (#227).
+        {
+            nk_console* page = nk_console_button(nav, "Row Page");
+            nk_console* row = nk_console_row_begin(page);
+            nk_console* tools = nk_console_button(row, "Tools");
+            nk_console_button(tools, "Hammer"); // gives tools children, making it a sub-page
+            nk_console_row_end(row);
+            assert(tools->parent == row);
+
+            // Open the tools sub-page.
+            nk_console_set_active_parent(tools);
+            assert(nk_console_active_parent(nav) == tools);
+
+            // Press Back from inside tools: navigate_back(back_button->parent) == navigate_back(tools).
+            nk_console_navigate_back(tools);
+
+            // The row is skipped: the active parent is the row's parent page, and
+            // focus lands on the row (so its active child stays highlighted).
+            assert(nk_console_active_parent(nav) == page);
+            assert(nk_console_get_active_widget(row) == row);
+        }
+
         nk_console_free(nav);
     }
     nk_end(ctx);


### PR DESCRIPTION
When navigating back from a widget inside a row, `nk_console_navigate_back` now walks up past any `NK_CONSOLE_ROW` widgets to their parent, preventing the crash described in #227.

Fixes #227