### PR TITLE
Fix NULL-deref in combobox with NULL items

### DIFF
--- a/nuklear_console_combobox.h
+++ b/nuklear_console_combobox.h
@@ -117,6 +117,14 @@ NK_API void nk_console_combobox_update(nk_console* combobox, const char* label, 
     nk_console* backbutton = nk_console_button_onclick(combobox, label, &nk_console_combobox_button_click);
     nk_console_button_set_symbol(backbutton, NK_SYMBOL_TRIANGLE_UP);
 
+    // NULL items: clamp selected and leave only the back button.
+    if (items_separated_by_separator == NULL) {
+        if (selected != NULL) {
+            *selected = 0;
+        }
+        return;
+    }
+
     // Add new items as children
     const char* button_text_start = items_separated_by_separator;
     int text_length = 0;

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -228,16 +228,6 @@ int main() {
         assert(combobox != NULL);
     }
 
-    // nk_console_combobox() with NULL items must not crash
-    {
-        int value_null_combobox = 5;
-        nk_console* combobox_null = nk_console_combobox(console, "NullComboBox", NULL, '|', &value_null_combobox);
-        assert(combobox_null != NULL);
-        assert(value_null_combobox == 0);
-        // Only the back button should be a child (no item children).
-        assert(cvector_size(combobox_null->children) == 1);
-    }
-
     // nk_console_property_int/float()
     {
         int property_int_test = 10;

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -228,6 +228,16 @@ int main() {
         assert(combobox != NULL);
     }
 
+    // nk_console_combobox() with NULL items must not crash
+    {
+        int value_null_combobox = 5;
+        nk_console* combobox_null = nk_console_combobox(console, "NullComboBox", NULL, '|', &value_null_combobox);
+        assert(combobox_null != NULL);
+        assert(value_null_combobox == 0);
+        // Only the back button should be a child (no item children).
+        assert(cvector_size(combobox_null->children) == 1);
+    }
+
     // nk_console_property_int/float()
     {
         int property_int_test = 10;


### PR DESCRIPTION
Guard `nk_console_combobox_update` against a NULL `items_separated_by_separator` by early-returning after adding the back button and clamping `*selected` to 0, mirroring the existing `!combobox || !combobox->data` guard. A test is added that constructs a combobox with NULL items and asserts no crash, `*selected == 0`, and exactly one child (the back button).

Fixes #226