### PR TITLE
Widget: Chart

### DIFF
--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -65,6 +65,10 @@ static nk_bool checkbox4 = nk_false;
 static nk_bool checkbox5 = nk_false;
 static nk_bool checkbox6 = nk_true;
 
+// Chart
+static const float chart_line_values[] = {0.1f, 0.5f, 0.3f, 0.9f, 0.4f, 0.7f, 0.2f, 0.8f};
+static const float chart_col_values[] = {0.6f, 0.3f, 0.8f, 0.1f, 0.5f, 0.9f, 0.4f, 0.7f};
+
 // Messages
 static int message_count = 0;
 
@@ -324,6 +328,16 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
             nk_console_row_end(row);
 
             nk_console_button_onclick(spacing, "Back", &nk_console_button_back);
+        }
+
+        // Chart
+        struct nk_console* chart_button = nk_console_button(widgets, "Chart");
+        {
+            nk_console_label(chart_button, "Line Chart");
+            nk_console_chart(chart_button, NULL, NK_CHART_LINES, chart_line_values, 8, 0.0f, 1.0f);
+            nk_console_label(chart_button, "Column Chart");
+            nk_console_chart(chart_button, NULL, NK_CHART_COLUMN, chart_col_values, 8, 0.0f, 1.0f);
+            nk_console_button_onclick(chart_button, "Back", &nk_console_button_back);
         }
 
         // Horizontal Rule

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -78,6 +78,7 @@ typedef enum {
     NK_CONSOLE_RULE_HORIZONTAL,
     NK_CONSOLE_TREE,
     NK_CONSOLE_LIST_VIEW,
+    NK_CONSOLE_CHART,
 } nk_console_widget_type;
 
 typedef struct nk_console_message {
@@ -319,6 +320,7 @@ NK_API nk_bool nk_console_navigate_to_path(nk_console* console, const char* path
 
 #define NK_CONSOLE_HEADER_ONLY
 #include "nuklear_console_button.h"
+#include "nuklear_console_chart.h"
 #include "nuklear_console_checkbox.h"
 #include "nuklear_console_color.h"
 #include "nuklear_console_combobox.h"
@@ -514,6 +516,7 @@ extern "C" {
 #endif
 
 #include "nuklear_console_button.h"
+#include "nuklear_console_chart.h"
 #include "nuklear_console_checkbox.h"
 #include "nuklear_console_color.h"
 #include "nuklear_console_combobox.h"

--- a/nuklear_console_chart.h
+++ b/nuklear_console_chart.h
@@ -1,0 +1,106 @@
+#ifndef NK_CONSOLE_CHART_H__
+#define NK_CONSOLE_CHART_H__
+
+typedef struct nk_console_chart_data {
+    enum nk_chart_type type;
+    const float* values;
+    int count;
+    float min_value;
+    float max_value;
+} nk_console_chart_data;
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/** Add a chart widget displaying @p values of the given @p type. @return The new widget. */
+NK_API nk_console* nk_console_chart(nk_console* parent, const char* label, enum nk_chart_type type, const float* values, int count, float min_value, float max_value);
+/** Update the data of an existing chart widget. */
+NK_API void nk_console_chart_update(nk_console* chart, const float* values, int count, float min_value, float max_value);
+/** Render the chart widget. @return The bounding rect. */
+NK_API struct nk_rect nk_console_chart_render(nk_console* console);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // NK_CONSOLE_CHART_H__
+
+#if defined(NK_CONSOLE_IMPLEMENTATION) && !defined(NK_CONSOLE_HEADER_ONLY)
+#ifndef NK_CONSOLE_CHART_IMPLEMENTATION_ONCE
+#define NK_CONSOLE_CHART_IMPLEMENTATION_ONCE
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+NK_API struct nk_rect nk_console_chart_render(nk_console* console) {
+    nk_console_chart_data* data = (nk_console_chart_data*)console->data;
+    if (data == NULL || data->values == NULL || data->count <= 0) {
+        return nk_rect(0, 0, 0, 0);
+    }
+
+    nk_console_layout_widget(console);
+
+    // Display the label when provided.
+    if (console->label != NULL && nk_strlen(console->label) > 0) {
+        nk_label(console->ctx, console->label, NK_TEXT_LEFT);
+    }
+
+    struct nk_rect widget_bounds = nk_layout_widget_bounds(console->ctx);
+
+    if (console->disabled) {
+        nk_widget_disable_begin(console->ctx);
+    }
+
+    nk_plot(console->ctx, data->type, data->values, data->count, 0);
+
+    if (console->disabled) {
+        nk_widget_disable_end(console->ctx);
+    }
+
+    if (nk_console_is_active_widget(console)) {
+        nk_console_check_up_down(console);
+        nk_console_check_tooltip(console);
+    }
+
+    return widget_bounds;
+}
+
+NK_API nk_console* nk_console_chart(nk_console* parent, const char* label, enum nk_chart_type type, const float* values, int count, float min_value, float max_value) {
+    NK_ASSERT(parent != NULL);
+    NK_ASSERT(values != NULL);
+    NK_ASSERT(count > 0);
+
+    nk_console_chart_data* data = (nk_console_chart_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_chart_data));
+    nk_zero(data, sizeof(nk_console_chart_data));
+    data->type = type;
+    data->values = values;
+    data->count = count;
+    data->min_value = min_value;
+    data->max_value = max_value;
+
+    nk_console* chart = nk_console_label(parent, label);
+    chart->render = nk_console_chart_render;
+    chart->type = NK_CONSOLE_CHART;
+    chart->selectable = nk_false;
+    chart->columns = label != NULL ? 2 : 1;
+    chart->data = (void*)data;
+    return chart;
+}
+
+NK_API void nk_console_chart_update(nk_console* chart, const float* values, int count, float min_value, float max_value) {
+    if (chart == NULL || chart->data == NULL) return;
+    nk_console_chart_data* data = (nk_console_chart_data*)chart->data;
+    data->values = values;
+    data->count = count;
+    data->min_value = min_value;
+    data->max_value = max_value;
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // NK_CONSOLE_CHART_IMPLEMENTATION_ONCE
+#endif // NK_CONSOLE_IMPLEMENTATION

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -418,6 +418,17 @@ int main() {
         assert(radio3 != NULL);
     }
 
+    // nk_console_chart()
+    {
+        static const float chart_values[] = {0.1f, 0.5f, 0.3f, 0.8f, 0.2f, 0.9f};
+        nk_console* chart = nk_console_chart(console, "Chart", NK_CHART_LINES, chart_values, 6, 0.0f, 1.0f);
+        assert(chart != NULL);
+        assert(chart->type == NK_CONSOLE_CHART);
+        nk_console_chart_update(chart, chart_values, 6, 0.0f, 1.0f);
+        nk_console* chart_col = nk_console_chart(console, NULL, NK_CHART_COLUMN, chart_values, 6, 0.0f, 1.0f);
+        assert(chart_col != NULL);
+    }
+
     // nk_console_rule_horizontal()
     {
         struct nk_color rule_color = {200, 200, 200, 255};


### PR DESCRIPTION
Adds `nk_console_chart()` widget supporting `NK_CHART_LINES` and `NK_CHART_COLUMN` types via Nuklear's `nk_plot()` API, with `nk_console_chart_update()` for live data updates. Includes tests and demo entries.

Fixes #137