### PR TITLE
Message improvements

### DIFF
--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -67,6 +67,12 @@ static nk_bool checkbox6 = nk_true;
 
 // Messages
 static int message_count = 0;
+static nk_console_message_position message_positions[] = {
+    NK_CONSOLE_MESSAGE_POSITION_BOTTOM,
+    NK_CONSOLE_MESSAGE_POSITION_TOP,
+    NK_CONSOLE_MESSAGE_POSITION_LEFT,
+    NK_CONSOLE_MESSAGE_POSITION_RIGHT,
+};
 
 // File
 static char file_path_buffer[4096] = {0};
@@ -147,6 +153,12 @@ void nk_console_demo_show_message(struct nk_console* button, void* user_data) {
 void nk_console_demo_show_marquee_message(struct nk_console* button, void* user_data) {
     NK_UNUSED(user_data);
     nk_console_show_message(button, "This is a very long marquee message that scrolls across the screen because it is too wide to fit!");
+}
+
+void nk_console_demo_show_message_from(struct nk_console* button, void* user_data) {
+    // The desired edge is passed through as user_data.
+    nk_console_set_message_position(button, *(nk_console_message_position*)user_data);
+    nk_console_show_message(button, nk_console_get_label(button));
 }
 
 void nk_console_quit_button_focused(struct nk_console* widget, void* user_data) {
@@ -478,8 +490,28 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         }
 
         // Messages
-        nk_console_button_onclick(widgets, "Show Message", &nk_console_demo_show_message);
-        nk_console_button_onclick(widgets, "Show Marquee Message", &nk_console_demo_show_marquee_message);
+        struct nk_console* messages = nk_console_button(widgets, "Messages");
+        {
+            nk_console_set_tooltip(messages, "Notification messages that slide in from a screen edge.");
+
+            // Demonstrate a message animating from each edge. The chosen edge
+            // persists, so the buttons below also use the most recent one.
+            nk_console_add_event_handler(nk_console_button(messages, "Slide from Bottom"),
+                NK_CONSOLE_EVENT_CLICKED, &nk_console_demo_show_message_from, &message_positions[0], NULL);
+            nk_console_add_event_handler(nk_console_button(messages, "Slide from Top"),
+                NK_CONSOLE_EVENT_CLICKED, &nk_console_demo_show_message_from, &message_positions[1], NULL);
+            nk_console_add_event_handler(nk_console_button(messages, "Slide from Left"),
+                NK_CONSOLE_EVENT_CLICKED, &nk_console_demo_show_message_from, &message_positions[2], NULL);
+            nk_console_add_event_handler(nk_console_button(messages, "Slide from Right"),
+                NK_CONSOLE_EVENT_CLICKED, &nk_console_demo_show_message_from, &message_positions[3], NULL);
+
+            nk_console_button_onclick(messages, "Show Message", &nk_console_demo_show_message);
+            nk_console_button_onclick(messages, "Show Marquee Message", &nk_console_demo_show_marquee_message);
+
+            nk_console_button_set_symbol(
+                nk_console_button_onclick(messages, "Back", &nk_console_button_back),
+                NK_SYMBOL_TRIANGLE_LEFT);
+        }
 
         // Long tooltip
         nk_console_button_onclick(widgets, "Long Tooltip Button", NULL)

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -86,6 +86,19 @@ typedef struct nk_console_message {
     float scroll_x;
 } nk_console_message;
 
+/**
+ * Indicates which screen edge a message slides in from.
+ *
+ * @see nk_console_set_message_position()
+ * @see nk_console_get_message_position()
+ */
+typedef enum {
+    NK_CONSOLE_MESSAGE_POSITION_BOTTOM = 0, /** Slide in from the bottom of the screen (default). */
+    NK_CONSOLE_MESSAGE_POSITION_TOP, /** Slide in from the top edge. */
+    NK_CONSOLE_MESSAGE_POSITION_LEFT, /** Slide in from the left edge. */
+    NK_CONSOLE_MESSAGE_POSITION_RIGHT, /** Slide in from the right edge. */
+} nk_console_message_position;
+
 typedef struct nk_console {
     nk_console_widget_type type;
     const char* label;
@@ -125,6 +138,14 @@ typedef struct nk_console_top_data {
      * When set, will determine where messages should appear on the screen.
      */
     struct nk_rect message_bounds;
+
+    /**
+     * Which screen edge messages slide in from.
+     *
+     * @see nk_console_set_message_position()
+     * @see nk_console_get_message_position()
+     */
+    nk_console_message_position message_position;
 
     /**
      * The gamepad system to use for gamepad input.

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -13,6 +13,27 @@ extern "C" {
  */
 NK_API void nk_console_show_message(nk_console* console, const char* text);
 
+/**
+ * Set the bounding rectangle used to position messages.
+ *
+ * When the width is zero (the default), messages are placed relative to the
+ * current Nuklear window bounds. Set a non-zero rect to pin messages to a
+ * specific area of the screen instead.
+ *
+ * @param console Any widget within the console family.
+ * @param bounds  The screen-space rect that messages should be anchored to.
+ */
+NK_API void nk_console_set_message_bounds(nk_console* console, struct nk_rect bounds);
+
+/**
+ * Get the bounding rectangle currently used to position messages.
+ *
+ * @param console Any widget within the console family.
+ * @return The rect set by nk_console_set_message_bounds(), or a zeroed rect
+ *         when the default (window-relative) placement is active.
+ */
+NK_API struct nk_rect nk_console_get_message_bounds(nk_console* console);
+
 #if defined(__cplusplus)
 }
 #endif
@@ -105,12 +126,20 @@ NK_API void nk_console_message_render(nk_console* console, nk_console_message* m
 
     // Animations can be applied if delta time is available.
     if (ctx->delta_time_seconds > 0) {
-        // TODO(RobLoach): Apply easing to the message animation.
+        float slide_h = text_height + padding.y * 2 + border * 2.0f;
+        float t = 0.0f;
         if (message->duration <= 1.0f) {
-            ctx->input.mouse.pos.y += (int)((1.0f - message->duration) * (text_height + padding.y * 2 + border * 2.0f));
+            // Slide out: t goes 0->1 as duration drops from 1->0.
+            t = 1.0f - message->duration;
         }
         else if (message->duration >= NK_CONSOLE_MESSAGE_DURATION - 1.0f) {
-            ctx->input.mouse.pos.y += (int)((message->duration - NK_CONSOLE_MESSAGE_DURATION + 1.0f) * (text_height + padding.y * 2 + border * 2.0f));
+            // Slide in: t goes 1->0 as duration drops from DURATION->DURATION-1.
+            t = message->duration - NK_CONSOLE_MESSAGE_DURATION + 1.0f;
+        }
+        if (t > 0.0f) {
+            // Smoothstep easing: t_s = t*t*(3-2t)
+            float t_s = t * t * (3.0f - 2.0f * t);
+            ctx->input.mouse.pos.y += (int)(t_s * slide_h);
         }
     }
 
@@ -159,6 +188,29 @@ NK_API void nk_console_render_message(nk_console* console) {
     if (clear_all) {
         cvector_clear(data->messages);
     }
+}
+
+NK_API void nk_console_set_message_bounds(nk_console* console, struct nk_rect bounds) {
+    if (console == NULL) {
+        return;
+    }
+    nk_console_top_data* data = (nk_console_top_data*)(nk_console_get_top(console)->data);
+    if (data == NULL) {
+        return;
+    }
+    data->message_bounds = bounds;
+}
+
+NK_API struct nk_rect nk_console_get_message_bounds(nk_console* console) {
+    struct nk_rect zero = {0, 0, 0, 0};
+    if (console == NULL) {
+        return zero;
+    }
+    nk_console_top_data* data = (nk_console_top_data*)(nk_console_get_top(console)->data);
+    if (data == NULL) {
+        return zero;
+    }
+    return data->message_bounds;
 }
 
 #if defined(__cplusplus)

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -16,12 +16,12 @@ NK_API void nk_console_show_message(nk_console* console, const char* text);
 /**
  * Set the bounding rectangle used to position messages.
  *
- * When the width is zero (the default), messages are placed relative to the
- * current Nuklear window bounds. Set a non-zero rect to pin messages to a
- * specific area of the screen instead.
+ * When the width is zero (the default), messages are placed relative to the current Nuklear window bounds. Set a non-zero rect to pin messages to a specific area of the screen instead.
  *
  * @param console Any widget within the console family.
  * @param bounds  The screen-space rect that messages should be anchored to.
+ *
+ * @see nk_console_get_message_bounds()
  */
 NK_API void nk_console_set_message_bounds(nk_console* console, struct nk_rect bounds);
 
@@ -29,10 +29,34 @@ NK_API void nk_console_set_message_bounds(nk_console* console, struct nk_rect bo
  * Get the bounding rectangle currently used to position messages.
  *
  * @param console Any widget within the console family.
- * @return The rect set by nk_console_set_message_bounds(), or a zeroed rect
- *         when the default (window-relative) placement is active.
+ * @return The rect set by nk_console_set_message_bounds(), or a zeroed rect when the default (window-relative) placement is active.
+ *
+ * @see nk_console_set_message_bounds()
  */
 NK_API struct nk_rect nk_console_get_message_bounds(nk_console* console);
+
+/**
+ * Set the screen edge that messages slide in from.
+ *
+ * Defaults to NK_CONSOLE_MESSAGE_POSITION_BOTTOM.
+ *
+ * @param console  Any widget within the console family.
+ * @param position The edge that messages should animate from.
+ *
+ * @see nk_console_get_message_position()
+ */
+NK_API void nk_console_set_message_position(nk_console* console, nk_console_message_position position);
+
+/**
+ * Get the screen edge that messages slide in from.
+ *
+ * @param console Any widget within the console family.
+ * @return The position set by nk_console_set_message_position(), or
+ *         NK_CONSOLE_MESSAGE_POSITION_BOTTOM by default.
+ *
+ * @see nk_console_set_message_position()
+ */
+NK_API nk_console_message_position nk_console_get_message_position(nk_console* console);
 
 #if defined(__cplusplus)
 }
@@ -52,7 +76,7 @@ extern "C" {
 /**
  * A float determining how many seconds messages should be shown for.
  */
-#define NK_CONSOLE_MESSAGE_DURATION 4.0f
+#define NK_CONSOLE_MESSAGE_DURATION 5.0f
 #endif // NK_CONSOLE_MESSAGE_DURATION
 
 NK_API void nk_console_show_message(nk_console* console, const char* text) {
@@ -118,15 +142,17 @@ NK_API void nk_console_message_render(nk_console* console, nk_console_message* m
     // Backup the mouse information as we'll be mocking it with a tooltip.
     struct nk_vec2 mouse_pos = ctx->input.mouse.pos;
 
-    // Display the tooltip at the bottom of the window, by manipulating the mouse position
+    // Position the message against the configured screen edge by manipulating
+    // the mouse position (the message is drawn as a tooltip).
     struct nk_rect bounds = data->message_bounds.w == 0 ? nk_window_get_bounds(ctx) : data->message_bounds;
     bounds.w -= border;
+    nk_console_message_position position = data->message_position;
+    float slide_h = text_height + padding.y * 2 + border * 2.0f;
     ctx->input.mouse.pos.x = bounds.x;
-    ctx->input.mouse.pos.y = bounds.y + bounds.h - text_height - padding.y * 2 - border * 2.0f;
+    ctx->input.mouse.pos.y = (position == NK_CONSOLE_MESSAGE_POSITION_BOTTOM) ? bounds.y + bounds.h - slide_h : bounds.y;
 
-    // Animations can be applied if delta time is available.
+    // Slide the message off its anchored edge as it animates in and out.
     if (ctx->delta_time_seconds > 0) {
-        float slide_h = text_height + padding.y * 2 + border * 2.0f;
         float t = 0.0f;
         if (message->duration <= 1.0f) {
             // Slide out: t goes 0->1 as duration drops from 1->0.
@@ -139,7 +165,21 @@ NK_API void nk_console_message_render(nk_console* console, nk_console_message* m
         if (t > 0.0f) {
             // Smoothstep easing: t_s = t*t*(3-2t)
             float t_s = t * t * (3.0f - 2.0f * t);
-            ctx->input.mouse.pos.y += (int)(t_s * slide_h);
+            switch (position) {
+                case NK_CONSOLE_MESSAGE_POSITION_TOP:
+                    ctx->input.mouse.pos.y -= (int)(t_s * slide_h);
+                    break;
+                case NK_CONSOLE_MESSAGE_POSITION_LEFT:
+                    ctx->input.mouse.pos.x -= (int)(t_s * bounds.w);
+                    break;
+                case NK_CONSOLE_MESSAGE_POSITION_RIGHT:
+                    ctx->input.mouse.pos.x += (int)(t_s * bounds.w);
+                    break;
+                case NK_CONSOLE_MESSAGE_POSITION_BOTTOM:
+                default:
+                    ctx->input.mouse.pos.y += (int)(t_s * slide_h);
+                    break;
+            }
         }
     }
 
@@ -211,6 +251,28 @@ NK_API struct nk_rect nk_console_get_message_bounds(nk_console* console) {
         return zero;
     }
     return data->message_bounds;
+}
+
+NK_API void nk_console_set_message_position(nk_console* console, nk_console_message_position position) {
+    if (console == NULL) {
+        return;
+    }
+    nk_console_top_data* data = (nk_console_top_data*)(nk_console_get_top(console)->data);
+    if (data == NULL) {
+        return;
+    }
+    data->message_position = position;
+}
+
+NK_API nk_console_message_position nk_console_get_message_position(nk_console* console) {
+    if (console == NULL) {
+        return NK_CONSOLE_MESSAGE_POSITION_BOTTOM;
+    }
+    nk_console_top_data* data = (nk_console_top_data*)(nk_console_get_top(console)->data);
+    if (data == NULL) {
+        return NK_CONSOLE_MESSAGE_POSITION_BOTTOM;
+    }
+    return data->message_position;
 }
 
 #if defined(__cplusplus)

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -370,6 +370,17 @@ int main() {
         nk_console_show_message(console, "This is an info message");
     }
 
+    // nk_console_set_message_position() / nk_console_get_message_position()
+    {
+        assert(nk_console_get_message_position(console) == NK_CONSOLE_MESSAGE_POSITION_BOTTOM);
+        nk_console_set_message_position(console, NK_CONSOLE_MESSAGE_POSITION_TOP);
+        assert(nk_console_get_message_position(console) == NK_CONSOLE_MESSAGE_POSITION_TOP);
+        nk_console_set_message_position(console, NK_CONSOLE_MESSAGE_POSITION_LEFT);
+        assert(nk_console_get_message_position(console) == NK_CONSOLE_MESSAGE_POSITION_LEFT);
+        nk_console_set_message_position(console, NK_CONSOLE_MESSAGE_POSITION_BOTTOM);
+        assert(nk_console_get_message_position(console) == NK_CONSOLE_MESSAGE_POSITION_BOTTOM);
+    }
+
     // nk_console_row()
     {
         nk_console* row = nk_console_row_begin(console);


### PR DESCRIPTION
Applies smoothstep easing to the slide-in/out animation so transitions look smoother, and adds `nk_console_set_message_bounds()`/`nk_console_get_message_bounds()` so callers can control where messages are rendered.

Fixes #102