### PR TITLE
Switch nk_bool flags to nk_uint with NK_FLAG enums

### DIFF
--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -127,13 +127,13 @@ void theme_changed(struct nk_console* combobox, void* user_data) {
 void exclude_other_checkbox(struct nk_console* unused, void* user_data) {
     NK_UNUSED(unused);
     nk_console* other = (nk_console*)user_data;
-    NK_FLAG_TOGGLE(other->flags, NK_CONSOLE_FLAG_DISABLED);
+    nk_console_set_disabled(other, !nk_console_get_disabled(other));
 }
 
 void toggle_visibility(struct nk_console* unused, void* user_data) {
     NK_UNUSED(unused);
     struct nk_console* other = (nk_console*)user_data;
-    NK_FLAG_TOGGLE(other->flags, NK_CONSOLE_FLAG_VISIBLE);
+    nk_console_set_visible(other, !nk_console_get_visible(other));
 }
 
 void nk_console_password_back(struct nk_console* widget, void* user_data) {
@@ -222,13 +222,13 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         {
             nk_console_label(label_button, "Simple label.");
             struct nk_console* label1 = nk_console_label(label_button, "Selectable label #1");
-            label1->flags |= NK_CONSOLE_FLAG_SELECTABLE;
+            nk_console_set_selectable(label1, nk_true);
             nk_console_add_event(label1, NK_CONSOLE_EVENT_CLICKED, &nk_console_demo_show_message);
 
-            NK_FLAG_SET(nk_console_label(label_button, "Selectable label #2.")->flags, NK_CONSOLE_FLAG_SELECTABLE);
+            nk_console_set_selectable(nk_console_label(label_button, "Selectable label #2."), nk_true);
             nk_console_label(label_button, "This is a label that will wrap across multiple lines.")
                 ->height = 128;
-            NK_FLAG_SET(nk_console_label(label_button, "This is a disabled label")->flags, NK_CONSOLE_FLAG_DISABLED);
+            nk_console_set_disabled(nk_console_label(label_button, "This is a disabled label"), nk_true);
             nk_console_label(label_button, "Center Aligned Label!")
                 ->alignment = NK_TEXT_CENTERED;
             nk_console_label(label_button, "Right Aligned Label!")
@@ -242,7 +242,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
                 ->tooltip = "This is a checkbox!";
             nk_console_checkbox(checkbox_button, "Right aligned", &checkbox3)
                 ->alignment = NK_TEXT_RIGHT;
-            NK_FLAG_SET(nk_console_checkbox(checkbox_button, "Disabled Checkbox", &checkbox2)->flags, NK_CONSOLE_FLAG_DISABLED);
+            nk_console_set_disabled(nk_console_checkbox(checkbox_button, "Disabled Checkbox", &checkbox2), nk_true);
 
             // Onchange callbacks can be used to implement custom logic.
             // These two checkboxes disable each other when checked.
@@ -263,7 +263,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         {
             nk_console_button(buttons, "Button");
             nk_console_button(buttons, "Button #2");
-            NK_FLAG_SET(nk_console_button(buttons, "Disabled Button")->flags, NK_CONSOLE_FLAG_DISABLED);
+            nk_console_set_disabled(nk_console_button(buttons, "Disabled Button"), nk_true);
 
             // Image Button
             struct nk_console* image_button = nk_console_button(buttons, "Image");
@@ -289,8 +289,8 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
             nk_console_radio(radios, "Center Aligned #2", &radio_option2)->alignment = NK_TEXT_CENTERED;
             nk_console_radio(radios, "Right Aligned #1", &radio_option2)->alignment = NK_TEXT_RIGHT;
             nk_console_radio(radios, "Right Aligned #2", &radio_option2)->alignment = NK_TEXT_RIGHT;
-            NK_FLAG_SET(nk_console_radio(radios, "Disabled", &radio_option2)->flags, NK_CONSOLE_FLAG_DISABLED);
-            NK_FLAG_CLEAR(nk_console_radio(radios, "Invisible", &radio_option2)->flags, NK_CONSOLE_FLAG_VISIBLE);
+            nk_console_set_disabled(nk_console_radio(radios, "Disabled", &radio_option2), nk_true);
+            nk_console_set_visible(nk_console_radio(radios, "Invisible", &radio_option2), nk_false);
 
             nk_console_button_onclick(radios, "Back", &nk_console_button_back);
         }
@@ -397,7 +397,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         struct nk_console* progressbar = nk_console_button(widgets, "Progress Bar");
         {
             nk_console_progress(progressbar, "Progress", &progressValue, 100);
-            NK_FLAG_SET(nk_console_progress(progressbar, "Progress (Disabled)", &progressValue, 100)->flags, NK_CONSOLE_FLAG_DISABLED);
+            nk_console_set_disabled(nk_console_progress(progressbar, "Progress (Disabled)", &progressValue, 100), nk_true);
             nk_console_button_onclick(progressbar, "Back", &nk_console_button_back);
         }
 
@@ -446,7 +446,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         {
             nk_console_slider_float(sliders, "Slider Float", 0.0f, &slider_float_test, 2.0f, 0.1f)->tooltip = "Slider float is cool! It's what you want to use.";
             nk_console_slider_int(sliders, "Slider Int", 0, &slider_int_test, 20, 1);
-            NK_FLAG_SET(nk_console_slider_int(sliders, "Slider Disabled", 0, &slider_int_test, 20, 1)->flags, NK_CONSOLE_FLAG_DISABLED);
+            nk_console_set_disabled(nk_console_slider_int(sliders, "Slider Disabled", 0, &slider_int_test, 20, 1), nk_true);
             nk_console_button_onclick(sliders, "Back", &nk_console_button_back);
         }
 
@@ -588,14 +588,14 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         nk_console_button_onclick(open_path, "Back", &nk_console_button_back);
     }
 
-    NK_FLAG_SET(nk_console_button(console, "Save Game")->flags, NK_CONSOLE_FLAG_DISABLED);
+    nk_console_set_disabled(nk_console_button(console, "Save Game"), nk_true);
 
     struct nk_console* quit_button = nk_console_button_onclick(console, "Quit Game", &button_clicked);
     nk_console_add_event(quit_button, NK_CONSOLE_EVENT_FOCUS, &nk_console_quit_button_focused);
 
     // Don't display the quit button on Emscripten.
     #ifdef PLATFORM_WEB
-    quit_button->flags &= ~(nk_uint)NK_CONSOLE_FLAG_VISIBLE;
+    nk_console_set_visible(quit_button, nk_false);
     #endif
 
     return console;

--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -127,13 +127,13 @@ void theme_changed(struct nk_console* combobox, void* user_data) {
 void exclude_other_checkbox(struct nk_console* unused, void* user_data) {
     NK_UNUSED(unused);
     nk_console* other = (nk_console*)user_data;
-    other->disabled = !other->disabled;
+    if (!(other->flags & NK_CONSOLE_FLAG_DISABLED)) other->flags |= NK_CONSOLE_FLAG_DISABLED; else other->flags &= ~(nk_uint)NK_CONSOLE_FLAG_DISABLED
 }
 
 void toggle_visibility(struct nk_console* unused, void* user_data) {
     NK_UNUSED(unused);
     struct nk_console* other = (nk_console*)user_data;
-    other->visible = !other->visible;
+    if (!(other->flags & NK_CONSOLE_FLAG_VISIBLE)) other->flags |= NK_CONSOLE_FLAG_VISIBLE; else other->flags &= ~(nk_uint)NK_CONSOLE_FLAG_VISIBLE
 }
 
 void nk_console_password_back(struct nk_console* widget, void* user_data) {
@@ -222,15 +222,15 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         {
             nk_console_label(label_button, "Simple label.");
             struct nk_console* label1 = nk_console_label(label_button, "Selectable label #1");
-            label1->selectable = nk_true;
+            label1->flags |= NK_CONSOLE_FLAG_SELECTABLE;
             nk_console_add_event(label1, NK_CONSOLE_EVENT_CLICKED, &nk_console_demo_show_message);
 
             nk_console_label(label_button, "Selectable label #2.")
-                ->selectable = nk_true;
+                ->selectable_SET_;
             nk_console_label(label_button, "This is a label that will wrap across multiple lines.")
                 ->height = 128;
             nk_console_label(label_button, "This is a disabled label")
-                ->disabled = nk_true;
+                ->disabled_SET_;
             nk_console_label(label_button, "Center Aligned Label!")
                 ->alignment = NK_TEXT_CENTERED;
             nk_console_label(label_button, "Right Aligned Label!")
@@ -245,7 +245,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
             nk_console_checkbox(checkbox_button, "Right aligned", &checkbox3)
                 ->alignment = NK_TEXT_RIGHT;
             nk_console_checkbox(checkbox_button, "Disabled Checkbox", &checkbox2)
-                ->disabled = nk_true;
+                ->disabled_SET_;
 
             // Onchange callbacks can be used to implement custom logic.
             // These two checkboxes disable each other when checked.
@@ -267,7 +267,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
             nk_console_button(buttons, "Button");
             nk_console_button(buttons, "Button #2");
             nk_console_button(buttons, "Disabled Button")
-                ->disabled = nk_true;
+                ->disabled_SET_;
 
             // Image Button
             struct nk_console* image_button = nk_console_button(buttons, "Image");
@@ -293,8 +293,8 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
             nk_console_radio(radios, "Center Aligned #2", &radio_option2)->alignment = NK_TEXT_CENTERED;
             nk_console_radio(radios, "Right Aligned #1", &radio_option2)->alignment = NK_TEXT_RIGHT;
             nk_console_radio(radios, "Right Aligned #2", &radio_option2)->alignment = NK_TEXT_RIGHT;
-            nk_console_radio(radios, "Disabled", &radio_option2)->disabled = nk_true;
-            nk_console_radio(radios, "Invisible", &radio_option2)->visible = nk_false;
+            nk_console_radio(radios, "Disabled", &radio_option2)->disabled_SET_;
+            nk_console_radio(radios, "Invisible", &radio_option2)->visible_CLEAR_;
 
             nk_console_button_onclick(radios, "Back", &nk_console_button_back);
         }
@@ -402,7 +402,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         {
             nk_console_progress(progressbar, "Progress", &progressValue, 100);
             nk_console_progress(progressbar, "Progress (Disabled)", &progressValue, 100)
-                ->disabled = nk_true;
+                ->disabled_SET_;
             nk_console_button_onclick(progressbar, "Back", &nk_console_button_back);
         }
 
@@ -452,7 +452,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
             nk_console_slider_float(sliders, "Slider Float", 0.0f, &slider_float_test, 2.0f, 0.1f)->tooltip = "Slider float is cool! It's what you want to use.";
             nk_console_slider_int(sliders, "Slider Int", 0, &slider_int_test, 20, 1);
             nk_console_slider_int(sliders, "Slider Disabled", 0, &slider_int_test, 20, 1)
-                ->disabled = nk_true;
+                ->disabled_SET_;
             nk_console_button_onclick(sliders, "Back", &nk_console_button_back);
         }
 
@@ -594,14 +594,14 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         nk_console_button_onclick(open_path, "Back", &nk_console_button_back);
     }
 
-    nk_console_button(console, "Save Game")->disabled = nk_true;
+    nk_console_button(console, "Save Game")->disabled_SET_;
 
     struct nk_console* quit_button = nk_console_button_onclick(console, "Quit Game", &button_clicked);
     nk_console_add_event(quit_button, NK_CONSOLE_EVENT_FOCUS, &nk_console_quit_button_focused);
 
     // Don't display the quit button on Emscripten.
     #ifdef PLATFORM_WEB
-    quit_button->visible = nk_false;
+    quit_button->flags &= ~(nk_uint)NK_CONSOLE_FLAG_VISIBLE;
     #endif
 
     return console;

--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -127,13 +127,13 @@ void theme_changed(struct nk_console* combobox, void* user_data) {
 void exclude_other_checkbox(struct nk_console* unused, void* user_data) {
     NK_UNUSED(unused);
     nk_console* other = (nk_console*)user_data;
-    if (!(other->flags & NK_CONSOLE_FLAG_DISABLED)) other->flags |= NK_CONSOLE_FLAG_DISABLED; else other->flags &= ~(nk_uint)NK_CONSOLE_FLAG_DISABLED
+    NK_FLAG_TOGGLE(other->flags, NK_CONSOLE_FLAG_DISABLED)
 }
 
 void toggle_visibility(struct nk_console* unused, void* user_data) {
     NK_UNUSED(unused);
     struct nk_console* other = (nk_console*)user_data;
-    if (!(other->flags & NK_CONSOLE_FLAG_VISIBLE)) other->flags |= NK_CONSOLE_FLAG_VISIBLE; else other->flags &= ~(nk_uint)NK_CONSOLE_FLAG_VISIBLE
+    NK_FLAG_TOGGLE(other->flags, NK_CONSOLE_FLAG_VISIBLE)
 }
 
 void nk_console_password_back(struct nk_console* widget, void* user_data) {

--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -127,13 +127,13 @@ void theme_changed(struct nk_console* combobox, void* user_data) {
 void exclude_other_checkbox(struct nk_console* unused, void* user_data) {
     NK_UNUSED(unused);
     nk_console* other = (nk_console*)user_data;
-    NK_FLAG_TOGGLE(other->flags, NK_CONSOLE_FLAG_DISABLED)
+    NK_FLAG_TOGGLE(other->flags, NK_CONSOLE_FLAG_DISABLED);
 }
 
 void toggle_visibility(struct nk_console* unused, void* user_data) {
     NK_UNUSED(unused);
     struct nk_console* other = (nk_console*)user_data;
-    NK_FLAG_TOGGLE(other->flags, NK_CONSOLE_FLAG_VISIBLE)
+    NK_FLAG_TOGGLE(other->flags, NK_CONSOLE_FLAG_VISIBLE);
 }
 
 void nk_console_password_back(struct nk_console* widget, void* user_data) {
@@ -225,12 +225,10 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
             label1->flags |= NK_CONSOLE_FLAG_SELECTABLE;
             nk_console_add_event(label1, NK_CONSOLE_EVENT_CLICKED, &nk_console_demo_show_message);
 
-            nk_console_label(label_button, "Selectable label #2.")
-                ->selectable_SET_;
+            NK_FLAG_SET(nk_console_label(label_button, "Selectable label #2.")->flags, NK_CONSOLE_FLAG_SELECTABLE);
             nk_console_label(label_button, "This is a label that will wrap across multiple lines.")
                 ->height = 128;
-            nk_console_label(label_button, "This is a disabled label")
-                ->disabled_SET_;
+            NK_FLAG_SET(nk_console_label(label_button, "This is a disabled label")->flags, NK_CONSOLE_FLAG_DISABLED);
             nk_console_label(label_button, "Center Aligned Label!")
                 ->alignment = NK_TEXT_CENTERED;
             nk_console_label(label_button, "Right Aligned Label!")
@@ -244,8 +242,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
                 ->tooltip = "This is a checkbox!";
             nk_console_checkbox(checkbox_button, "Right aligned", &checkbox3)
                 ->alignment = NK_TEXT_RIGHT;
-            nk_console_checkbox(checkbox_button, "Disabled Checkbox", &checkbox2)
-                ->disabled_SET_;
+            NK_FLAG_SET(nk_console_checkbox(checkbox_button, "Disabled Checkbox", &checkbox2)->flags, NK_CONSOLE_FLAG_DISABLED);
 
             // Onchange callbacks can be used to implement custom logic.
             // These two checkboxes disable each other when checked.
@@ -266,8 +263,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         {
             nk_console_button(buttons, "Button");
             nk_console_button(buttons, "Button #2");
-            nk_console_button(buttons, "Disabled Button")
-                ->disabled_SET_;
+            NK_FLAG_SET(nk_console_button(buttons, "Disabled Button")->flags, NK_CONSOLE_FLAG_DISABLED);
 
             // Image Button
             struct nk_console* image_button = nk_console_button(buttons, "Image");
@@ -293,8 +289,8 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
             nk_console_radio(radios, "Center Aligned #2", &radio_option2)->alignment = NK_TEXT_CENTERED;
             nk_console_radio(radios, "Right Aligned #1", &radio_option2)->alignment = NK_TEXT_RIGHT;
             nk_console_radio(radios, "Right Aligned #2", &radio_option2)->alignment = NK_TEXT_RIGHT;
-            nk_console_radio(radios, "Disabled", &radio_option2)->disabled_SET_;
-            nk_console_radio(radios, "Invisible", &radio_option2)->visible_CLEAR_;
+            NK_FLAG_SET(nk_console_radio(radios, "Disabled", &radio_option2)->flags, NK_CONSOLE_FLAG_DISABLED);
+            NK_FLAG_CLEAR(nk_console_radio(radios, "Invisible", &radio_option2)->flags, NK_CONSOLE_FLAG_VISIBLE);
 
             nk_console_button_onclick(radios, "Back", &nk_console_button_back);
         }
@@ -401,8 +397,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         struct nk_console* progressbar = nk_console_button(widgets, "Progress Bar");
         {
             nk_console_progress(progressbar, "Progress", &progressValue, 100);
-            nk_console_progress(progressbar, "Progress (Disabled)", &progressValue, 100)
-                ->disabled_SET_;
+            NK_FLAG_SET(nk_console_progress(progressbar, "Progress (Disabled)", &progressValue, 100)->flags, NK_CONSOLE_FLAG_DISABLED);
             nk_console_button_onclick(progressbar, "Back", &nk_console_button_back);
         }
 
@@ -451,8 +446,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         {
             nk_console_slider_float(sliders, "Slider Float", 0.0f, &slider_float_test, 2.0f, 0.1f)->tooltip = "Slider float is cool! It's what you want to use.";
             nk_console_slider_int(sliders, "Slider Int", 0, &slider_int_test, 20, 1);
-            nk_console_slider_int(sliders, "Slider Disabled", 0, &slider_int_test, 20, 1)
-                ->disabled_SET_;
+            NK_FLAG_SET(nk_console_slider_int(sliders, "Slider Disabled", 0, &slider_int_test, 20, 1)->flags, NK_CONSOLE_FLAG_DISABLED);
             nk_console_button_onclick(sliders, "Back", &nk_console_button_back);
         }
 
@@ -594,7 +588,7 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
         nk_console_button_onclick(open_path, "Back", &nk_console_button_back);
     }
 
-    nk_console_button(console, "Save Game")->disabled_SET_;
+    NK_FLAG_SET(nk_console_button(console, "Save Game")->flags, NK_CONSOLE_FLAG_DISABLED);
 
     struct nk_console* quit_button = nk_console_button_onclick(console, "Quit Game", &button_clicked);
     nk_console_add_event(quit_button, NK_CONSOLE_EVENT_FOCUS, &nk_console_quit_button_focused);

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -154,7 +154,7 @@ typedef enum {
 
 typedef struct nk_console_top_data {
     nk_console* active_parent; /** The parent that is currently being displayed. */
-    nk_flags state; /** NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED | NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED | NK_CONSOLE_TOP_FLAG_AXIS_*_FIRED | NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_* */
+    nk_flags flags; /** NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED | NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED | NK_CONSOLE_TOP_FLAG_AXIS_*_FIRED | NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_* */
     nk_console* scroll_to_widget; /** When set by nk_console_navigate_back, the render loop scrolls the window to this widget's bounds. */
 
     /**
@@ -836,7 +836,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
     }
 
     // Only process an active input once.
-    if (NK_FLAG_DISABLED(data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (NK_FLAG_DISABLED(data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Page Up
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LB)) {
             int widgetIndex = nk_console_get_widget_index(widget);
@@ -855,7 +855,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
                 nk_console_set_active_widget(target);
                 data->scroll_to_widget = target;
             }
-            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         // Page Down
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RB)) {
@@ -877,7 +877,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
                 nk_console_set_active_widget(target);
                 data->scroll_to_widget = target;
             }
-            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         // Up
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_UP) || (up_held && up_down_repeat_fire)) {
@@ -890,7 +890,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
                     break;
                 }
             }
-            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         // Down
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_DOWN) || (down_held && up_down_repeat_fire)) {
@@ -905,12 +905,12 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
                     }
                 }
             }
-            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         // Back
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_B)) {
             if (nk_console_active_parent(top) == NULL) {
-                data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
                 return;
             }
 
@@ -918,7 +918,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
                 nk_console_navigate_back(widget->parent);
             }
 
-            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
     }
 }
@@ -1138,7 +1138,7 @@ static nk_bool nk_console_axis_tick(struct nk_console_axis_channel* ch, float st
  */
 static void nk_console_axis_update(nk_console* console) {
     nk_console_top_data* data = (nk_console_top_data*)console->data;
-    data->state &= ~(nk_flags)(NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED);
+    data->flags &= ~(nk_flags)(NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED);
     if (data->gamepads == NULL || console->ctx->delta_time_seconds <= 0) {
         return;
     }
@@ -1168,18 +1168,18 @@ static void nk_console_axis_update(nk_console* console) {
     // Up/Down
     if (nk_console_axis_tick(&data->axis_ud, NK_MAX(up_strength, down_strength), console->ctx->delta_time_seconds)) {
         if (up_strength >= down_strength) {
-            data->state |= NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED;
+            data->flags |= NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED;
         }
         else {
-            data->state |= NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED;
+            data->flags |= NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED;
         }
     }
     // Left/Right
     if (nk_console_axis_tick(&data->axis_lr, NK_MAX(left_strength, right_strength), console->ctx->delta_time_seconds)) {
         if (left_strength >= right_strength)
-            data->state |= NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED;
+            data->flags |= NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED;
         else
-            data->state |= NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED;
+            data->flags |= NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED;
     }
 }
 
@@ -1190,33 +1190,33 @@ static void nk_console_window_touch_drag(nk_console* console, nk_console_top_dat
     struct nk_input* in = &console->ctx->input;
     if (nk_window_is_hovered(console->ctx) && nk_input_is_mouse_pressed(in, NK_BUTTON_LEFT)) {
         struct nk_rect content = nk_window_get_content_region(console->ctx);
-        if (nk_input_is_mouse_hovering_rect(in, content)) top_data->state |= NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
-        else top_data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
-        if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED) {
+        if (nk_input_is_mouse_hovering_rect(in, content)) top_data->flags |= NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
+        else top_data->flags &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
+        if NK_FLAG_ENABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED) {
             top_data->drag_scroll_origin = in->mouse.pos;
             nk_window_get_scroll(console->ctx, &top_data->drag_scroll_start_x, &top_data->drag_scroll_start_y);
-            top_data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
+            top_data->flags &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
         }
     }
     if (nk_input_is_mouse_down(in, NK_BUTTON_LEFT)) {
-        if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED) {
+        if NK_FLAG_ENABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED) {
             float dy = top_data->drag_scroll_origin.y - in->mouse.pos.y;
             float dx = top_data->drag_scroll_origin.x - in->mouse.pos.x;
-            if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE) &&
+            if (NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE) &&
                 (dy * dy + dx * dx) > NK_CONSOLE_DRAG_THRESHOLD * NK_CONSOLE_DRAG_THRESHOLD) {
-                top_data->state |= NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
             }
-            if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE) {
+            if NK_FLAG_ENABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE) {
                 nk_uint sx = (nk_uint)NK_CLAMP(0.0f, (float)top_data->drag_scroll_start_x + dx, (float)top_data->drag_scroll_max_x);
                 nk_uint sy = (nk_uint)NK_CLAMP(0.0f, (float)top_data->drag_scroll_start_y + dy, (float)top_data->drag_scroll_max_y);
                 nk_window_set_scroll(console->ctx, sx, sy);
-                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
         }
     }
     else {
-        top_data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
-        top_data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
+        top_data->flags &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
+        top_data->flags &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
     }
 }
 
@@ -1284,7 +1284,7 @@ static void nk_console_update_drag_scroll(nk_console* console, nk_console_top_da
  */
 static void nk_console_render_top(nk_console* console) {
     nk_console_top_data* data = (nk_console_top_data*)console->data;
-    data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+    data->flags &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     nk_console_axis_update(console);
     nk_console_window_touch_drag(console, data);
     nk_console_trigger_event(data->active_parent, NK_CONSOLE_EVENT_PRE_PARENT_RENDER);
@@ -1340,10 +1340,10 @@ NK_API void nk_console_render(nk_console* console) {
         nk_window_get_scroll(console->ctx, &window_scroll_x, &window_scroll_y);
         widget_bounds.x -= (float)window_scroll_x;
         widget_bounds.y -= (float)window_scroll_y;
-        if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && nk_input_is_mouse_hovering_rect(&console->ctx->input, widget_bounds)) {
+        if (NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && nk_input_is_mouse_hovering_rect(&console->ctx->input, widget_bounds)) {
             if (nk_console_selectable(console)) {
                 nk_console_set_active_widget(console);
-                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
         }
     }
@@ -1411,7 +1411,7 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
     // Determine if the scrollbar is needed.
     top_data = (nk_console_top_data*)console->data;
     if ((flags & NK_WINDOW_SCROLL_AUTO_HIDE) != 0) {
-        if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED) {
+        if NK_FLAG_ENABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED) {
             flags |= (nk_flags)NK_WINDOW_NO_SCROLLBAR;
         }
         else {
@@ -1427,9 +1427,9 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
     // After all elements have been rendered, update the layout flags.
     if ((flags & NK_WINDOW_SCROLL_AUTO_HIDE) != 0) {
         if ((console->ctx->current->layout->at_y - console->ctx->current->layout->bounds.y) <= console->ctx->current->layout->bounds.h)
-            top_data->state |= NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
-        else top_data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
-        if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED) {
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
+        else top_data->flags &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
+        if NK_FLAG_ENABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED) {
             console->ctx->current->layout->flags |= (nk_flags)NK_WINDOW_NO_SCROLLBAR;
         }
         else {
@@ -1620,7 +1620,7 @@ NK_API void nk_console_navigate_back(nk_console* leaving_parent) {
     if (leaving_parent == top) {
         // Still trigger the back event if we're trying to leave the top.
         nk_console_trigger_event(leaving_parent, NK_CONSOLE_EVENT_BACK);
-        data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+        data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         return;
     }
 
@@ -1644,7 +1644,7 @@ NK_API void nk_console_navigate_back(nk_console* leaving_parent) {
     nk_console_set_active_widget(target);
     if (data != NULL) {
         data->scroll_to_widget = target;
-        data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+        data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     }
     nk_console_trigger_event(leaving_parent, NK_CONSOLE_EVENT_BACK);
 }
@@ -1740,10 +1740,10 @@ NK_API nk_bool nk_console_button_pushed(nk_console* console, int button) {
 
     // Keyboard/Mouse/Axis
     switch (button) {
-        case NK_GAMEPAD_BUTTON_UP: return NK_FLAG_ENABLED(data->state, NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_UP);
-        case NK_GAMEPAD_BUTTON_DOWN: return NK_FLAG_ENABLED(data->state, NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_DOWN);
-        case NK_GAMEPAD_BUTTON_LEFT: return NK_FLAG_ENABLED(data->state, NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_LEFT);
-        case NK_GAMEPAD_BUTTON_RIGHT: return NK_FLAG_ENABLED(data->state, NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_RIGHT);
+        case NK_GAMEPAD_BUTTON_UP: return NK_FLAG_ENABLED(data->flags, NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_UP);
+        case NK_GAMEPAD_BUTTON_DOWN: return NK_FLAG_ENABLED(data->flags, NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_DOWN);
+        case NK_GAMEPAD_BUTTON_LEFT: return NK_FLAG_ENABLED(data->flags, NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_LEFT);
+        case NK_GAMEPAD_BUTTON_RIGHT: return NK_FLAG_ENABLED(data->flags, NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_RIGHT);
         case NK_GAMEPAD_BUTTON_A: return nk_input_is_key_released(&console->ctx->input, NK_KEY_ENTER);
         case NK_GAMEPAD_BUTTON_B:
             // Escape Key

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -105,6 +105,10 @@ typedef enum {
     NK_CONSOLE_FLAG_VISIBLE    = NK_FLAG(2), /** When false, the widget will not be displayed. */
 } nk_console_flag;
 
+#define NK_FLAG_ENABLED(flags, flag)  ((flags) & (flag))
+#define NK_FLAG_DISABLED(flags, flag) (!((flags) & (flag)))
+#define NK_FLAG_TOGGLE(flags, flag)   ((flags) ^= (flag))
+
 typedef struct nk_console {
     nk_console_widget_type type;
     const char* label;
@@ -797,7 +801,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
     }
 
     // Only process an active input once.
-    if (!(data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (NK_FLAG_DISABLED(data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Page Up
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LB)) {
             int widgetIndex = nk_console_get_widget_index(widget);
@@ -914,7 +918,7 @@ NK_API nk_bool nk_console_selectable(nk_console* widget) {
         return nk_false;
     }
 
-    return (widget->flags & NK_CONSOLE_FLAG_SELECTABLE) && (widget->flags & NK_CONSOLE_FLAG_VISIBLE) && !(widget->flags & NK_CONSOLE_FLAG_DISABLED);
+    return NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_SELECTABLE) && NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_VISIBLE) && NK_FLAG_DISABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED);
 }
 
 #ifndef NK_CONSOLE_TOOLTIP_SCROLL_SPEED
@@ -1062,21 +1066,21 @@ static void nk_console_window_touch_drag(nk_console* console, nk_console_top_dat
         struct nk_rect content = nk_window_get_content_region(console->ctx);
         if (nk_input_is_mouse_hovering_rect(in, content)) top_data->state |= NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
         else top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
-        if ((top_data->state & NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED)) {
+        if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED) {
             top_data->drag_scroll_origin = in->mouse.pos;
             nk_window_get_scroll(console->ctx, &top_data->drag_scroll_start_x, &top_data->drag_scroll_start_y);
             top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
         }
     }
     if (nk_input_is_mouse_down(in, NK_BUTTON_LEFT)) {
-        if ((top_data->state & NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED)) {
+        if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED) {
             float dy = top_data->drag_scroll_origin.y - in->mouse.pos.y;
             float dx = top_data->drag_scroll_origin.x - in->mouse.pos.x;
-            if (!(top_data->state & NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE) &&
+            if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE) &&
                 (dy * dy + dx * dx) > NK_CONSOLE_DRAG_THRESHOLD * NK_CONSOLE_DRAG_THRESHOLD) {
                 top_data->state |= NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
             }
-            if ((top_data->state & NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE)) {
+            if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE) {
                 nk_uint sx = (nk_uint)NK_CLAMP(0.0f, (float)top_data->drag_scroll_start_x + dx, (float)top_data->drag_scroll_max_x);
                 nk_uint sy = (nk_uint)NK_CLAMP(0.0f, (float)top_data->drag_scroll_start_y + dy, (float)top_data->drag_scroll_max_y);
                 nk_window_set_scroll(console->ctx, sx, sy);
@@ -1173,7 +1177,7 @@ static void nk_console_render_top(nk_console* console) {
 }
 
 NK_API void nk_console_render(nk_console* console) {
-    if (console == NULL || !(console->flags & NK_CONSOLE_FLAG_VISIBLE)) {
+    if (console == NULL || NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_VISIBLE)) {
         return;
     }
 
@@ -1210,7 +1214,7 @@ NK_API void nk_console_render(nk_console* console) {
         nk_window_get_scroll(console->ctx, &window_scroll_x, &window_scroll_y);
         widget_bounds.x -= (float)window_scroll_x;
         widget_bounds.y -= (float)window_scroll_y;
-        if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && nk_input_is_mouse_hovering_rect(&console->ctx->input, widget_bounds)) {
+        if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && nk_input_is_mouse_hovering_rect(&console->ctx->input, widget_bounds)) {
             if (nk_console_selectable(console)) {
                 nk_console_set_active_widget(console);
                 top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
@@ -1281,7 +1285,7 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
     // Determine if the scrollbar is needed.
     top_data = (nk_console_top_data*)console->data;
     if ((flags & NK_WINDOW_SCROLL_AUTO_HIDE) != 0) {
-        if ((top_data->state & NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED)) {
+        if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED) {
             flags |= (nk_uint)NK_WINDOW_NO_SCROLLBAR;
         }
         else {
@@ -1299,7 +1303,7 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
         if ((console->ctx->current->layout->at_y - console->ctx->current->layout->bounds.y) <= console->ctx->current->layout->bounds.h)
             top_data->state |= NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
         else top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
-        if ((top_data->state & NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED)) {
+        if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED) {
             console->ctx->current->layout->flags |= (nk_uint)NK_WINDOW_NO_SCROLLBAR;
         }
         else {
@@ -1594,10 +1598,10 @@ NK_API nk_bool nk_console_button_pushed(nk_console* console, int button) {
 
     // Keyboard/Mouse/Axis
     switch (button) {
-        case NK_GAMEPAD_BUTTON_UP: return (data->state & NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_UP);
-        case NK_GAMEPAD_BUTTON_DOWN: return (data->state & NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_DOWN);
-        case NK_GAMEPAD_BUTTON_LEFT: return (data->state & NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_LEFT);
-        case NK_GAMEPAD_BUTTON_RIGHT: return (data->state & NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_RIGHT);
+        case NK_GAMEPAD_BUTTON_UP: return NK_FLAG_ENABLED(data->state, NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_UP);
+        case NK_GAMEPAD_BUTTON_DOWN: return NK_FLAG_ENABLED(data->state, NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_DOWN);
+        case NK_GAMEPAD_BUTTON_LEFT: return NK_FLAG_ENABLED(data->state, NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_LEFT);
+        case NK_GAMEPAD_BUTTON_RIGHT: return NK_FLAG_ENABLED(data->state, NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_RIGHT);
         case NK_GAMEPAD_BUTTON_A: return nk_input_is_key_released(&console->ctx->input, NK_KEY_ENTER);
         case NK_GAMEPAD_BUTTON_B:
             // Escape Key

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -107,9 +107,9 @@ typedef enum {
 
 #define NK_FLAG_ENABLED(flags, flag)  ((flags) & (flag))
 #define NK_FLAG_DISABLED(flags, flag) (!((flags) & (flag)))
-#define NK_FLAG_SET(flags, flag)      ((flags) |= (nk_uint)(flag))
-#define NK_FLAG_CLEAR(flags, flag)    ((flags) &= ~(nk_uint)(flag))
-#define NK_FLAG_TOGGLE(flags, flag)   ((flags) ^= (nk_uint)(flag))
+#define NK_FLAG_SET(flags, flag)      ((flags) |= (nk_flags)(flag))
+#define NK_FLAG_CLEAR(flags, flag)    ((flags) &= ~(nk_flags)(flag))
+#define NK_FLAG_TOGGLE(flags, flag)   ((flags) ^= (nk_flags)(flag))
 
 typedef struct nk_console {
     nk_console_widget_type type;
@@ -117,7 +117,7 @@ typedef struct nk_console {
     int label_length;
     nk_flags alignment;
 
-    nk_uint flags; /** NK_CONSOLE_FLAG_SELECTABLE | NK_CONSOLE_FLAG_DISABLED | NK_CONSOLE_FLAG_VISIBLE */
+    nk_flags flags; /** NK_CONSOLE_FLAG_SELECTABLE | NK_CONSOLE_FLAG_DISABLED | NK_CONSOLE_FLAG_VISIBLE */
     int columns; /** When set, will determine how many dynamic columns to set to for the active row. */
     int height; /** When set, will determine the height of the row. */
     const char* tooltip; /** Tooltip */
@@ -146,7 +146,7 @@ typedef enum {
 
 typedef struct nk_console_top_data {
     nk_console* active_parent; /** The parent that is currently being displayed. */
-    nk_uint state; /** NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED | NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED | NK_CONSOLE_TOP_FLAG_AXIS_*_FIRED | NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_* */
+    nk_flags state; /** NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED | NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED | NK_CONSOLE_TOP_FLAG_AXIS_*_FIRED | NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_* */
     nk_console* scroll_to_widget; /** When set by nk_console_navigate_back, the render loop scrolls the window to this widget's bounds. */
 
     /**
@@ -222,7 +222,7 @@ NK_API void nk_console_free(nk_console* console);
 /** Render the console inside the current Nuklear window. */
 NK_API void nk_console_render(nk_console* console);
 /** Render the console inside a new Nuklear window. @return The bounding rect of the rendered window. */
-NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* title, struct nk_rect bounds, nk_uint flags);
+NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* title, struct nk_rect bounds, nk_flags flags);
 
 /** @defgroup utilities Widget utilities */
 /** Return the top-level console that owns @p widget. */
@@ -277,6 +277,18 @@ NK_API void nk_console_set_height(nk_console* widget, int height);
 NK_API int nk_console_height(nk_console* widget);
 /** Return nk_true if @p widget can receive focus (is selectable). */
 NK_API nk_bool nk_console_selectable(nk_console* widget);
+/** Set the SELECTABLE flag on @p widget, controlling whether it can receive focus. */
+NK_API void nk_console_set_selectable(nk_console* widget, nk_bool selectable);
+/** Return nk_true if the SELECTABLE flag is set on @p widget (raw flag; see nk_console_selectable()). */
+NK_API nk_bool nk_console_get_selectable(nk_console* widget);
+/** Set the DISABLED flag on @p widget, greying it out and blocking interaction. */
+NK_API void nk_console_set_disabled(nk_console* widget, nk_bool disabled);
+/** Return nk_true if the DISABLED flag is set on @p widget. */
+NK_API nk_bool nk_console_get_disabled(nk_console* widget);
+/** Set the VISIBLE flag on @p widget, controlling whether it is displayed. */
+NK_API void nk_console_set_visible(nk_console* widget, nk_bool visible);
+/** Return nk_true if the VISIBLE flag is set on @p widget. */
+NK_API nk_bool nk_console_get_visible(nk_console* widget);
 
 /** Fire all handlers registered for @p type on @p widget. @return nk_true if any handler ran. */
 NK_API nk_bool nk_console_trigger_event(nk_console* widget, nk_console_event_type type);
@@ -923,6 +935,97 @@ NK_API nk_bool nk_console_selectable(nk_console* widget) {
     return NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_SELECTABLE) && NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_VISIBLE) && NK_FLAG_DISABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED);
 }
 
+/**
+ * Sets whether or not the given widget can be selected (the SELECTABLE flag).
+ *
+ * @see nk_console_get_selectable()
+ */
+NK_API void nk_console_set_selectable(nk_console* widget, nk_bool selectable) {
+    if (widget == NULL) {
+        return;
+    }
+    if (selectable) {
+        NK_FLAG_SET(widget->flags, NK_CONSOLE_FLAG_SELECTABLE);
+    }
+    else {
+        NK_FLAG_CLEAR(widget->flags, NK_CONSOLE_FLAG_SELECTABLE);
+    }
+}
+
+/**
+ * Gets whether or not the SELECTABLE flag is set on the given widget.
+ *
+ * This reports the raw flag state. To know whether the widget can actually be
+ * focused right now (selectable, visible, and not disabled), use
+ * nk_console_selectable().
+ *
+ * @see nk_console_selectable()
+ */
+NK_API nk_bool nk_console_get_selectable(nk_console* widget) {
+    if (widget == NULL) {
+        return nk_false;
+    }
+    return NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_SELECTABLE) != 0;
+}
+
+/**
+ * Sets whether or not the given widget is disabled (the DISABLED flag).
+ *
+ * @see nk_console_get_disabled()
+ */
+NK_API void nk_console_set_disabled(nk_console* widget, nk_bool disabled) {
+    if (widget == NULL) {
+        return;
+    }
+    if (disabled) {
+        NK_FLAG_SET(widget->flags, NK_CONSOLE_FLAG_DISABLED);
+    }
+    else {
+        NK_FLAG_CLEAR(widget->flags, NK_CONSOLE_FLAG_DISABLED);
+    }
+}
+
+/**
+ * Gets whether or not the DISABLED flag is set on the given widget.
+ *
+ * @see nk_console_set_disabled()
+ */
+NK_API nk_bool nk_console_get_disabled(nk_console* widget) {
+    if (widget == NULL) {
+        return nk_false;
+    }
+    return NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) != 0;
+}
+
+/**
+ * Sets whether or not the given widget is visible (the VISIBLE flag).
+ *
+ * @see nk_console_get_visible()
+ */
+NK_API void nk_console_set_visible(nk_console* widget, nk_bool visible) {
+    if (widget == NULL) {
+        return;
+    }
+    if (visible) {
+        NK_FLAG_SET(widget->flags, NK_CONSOLE_FLAG_VISIBLE);
+    }
+    else {
+        NK_FLAG_CLEAR(widget->flags, NK_CONSOLE_FLAG_VISIBLE);
+    }
+}
+
+/**
+ * Gets whether or not the VISIBLE flag is set on the given widget.
+ *
+ * @see nk_console_set_visible()
+ */
+NK_API nk_bool nk_console_get_visible(nk_console* widget) {
+    if (widget == NULL) {
+        return nk_false;
+    }
+    return NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_VISIBLE) != 0;
+}
+
 #ifndef NK_CONSOLE_TOOLTIP_SCROLL_SPEED
 #define NK_CONSOLE_TOOLTIP_SCROLL_SPEED NK_CONSOLE_MARQUEE_SCROLL_SPEED
 #endif
@@ -1014,7 +1117,7 @@ static nk_bool nk_console_axis_tick(struct nk_console_axis_channel* ch, float st
  */
 static void nk_console_axis_update(nk_console* console) {
     nk_console_top_data* data = (nk_console_top_data*)console->data;
-    data->state &= ~(nk_uint)(NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED);
+    data->state &= ~(nk_flags)(NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED);
     if (data->gamepads == NULL || console->ctx->delta_time_seconds <= 0) {
         return;
     }
@@ -1067,11 +1170,11 @@ static void nk_console_window_touch_drag(nk_console* console, nk_console_top_dat
     if (nk_window_is_hovered(console->ctx) && nk_input_is_mouse_pressed(in, NK_BUTTON_LEFT)) {
         struct nk_rect content = nk_window_get_content_region(console->ctx);
         if (nk_input_is_mouse_hovering_rect(in, content)) top_data->state |= NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
-        else top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
+        else top_data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
         if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED) {
             top_data->drag_scroll_origin = in->mouse.pos;
             nk_window_get_scroll(console->ctx, &top_data->drag_scroll_start_x, &top_data->drag_scroll_start_y);
-            top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
+            top_data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
         }
     }
     if (nk_input_is_mouse_down(in, NK_BUTTON_LEFT)) {
@@ -1091,8 +1194,8 @@ static void nk_console_window_touch_drag(nk_console* console, nk_console_top_dat
         }
     }
     else {
-        top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
-        top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
+        top_data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
+        top_data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
     }
 }
 
@@ -1160,7 +1263,7 @@ static void nk_console_update_drag_scroll(nk_console* console, nk_console_top_da
  */
 static void nk_console_render_top(nk_console* console) {
     nk_console_top_data* data = (nk_console_top_data*)console->data;
-    data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+    data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     nk_console_axis_update(console);
     nk_console_window_touch_drag(console, data);
     nk_console_trigger_event(data->active_parent, NK_CONSOLE_EVENT_PRE_PARENT_RENDER);
@@ -1273,7 +1376,7 @@ NK_API nk_console* nk_console_init(struct nk_context* context) {
  *
  * @return The resulting size of the window.
  */
-NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* title, struct nk_rect bounds, nk_uint flags) {
+NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* title, struct nk_rect bounds, nk_flags flags) {
     nk_console_top_data* top_data;
     struct nk_rect window_bounds;
     if (console == NULL) {
@@ -1288,10 +1391,10 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
     top_data = (nk_console_top_data*)console->data;
     if ((flags & NK_WINDOW_SCROLL_AUTO_HIDE) != 0) {
         if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED) {
-            flags |= (nk_uint)NK_WINDOW_NO_SCROLLBAR;
+            flags |= (nk_flags)NK_WINDOW_NO_SCROLLBAR;
         }
         else {
-            flags &= ~(nk_uint)NK_WINDOW_NO_SCROLLBAR;
+            flags &= ~(nk_flags)NK_WINDOW_NO_SCROLLBAR;
         }
     }
 
@@ -1304,12 +1407,12 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
     if ((flags & NK_WINDOW_SCROLL_AUTO_HIDE) != 0) {
         if ((console->ctx->current->layout->at_y - console->ctx->current->layout->bounds.y) <= console->ctx->current->layout->bounds.h)
             top_data->state |= NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
-        else top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
+        else top_data->state &= ~(nk_flags)NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
         if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED) {
-            console->ctx->current->layout->flags |= (nk_uint)NK_WINDOW_NO_SCROLLBAR;
+            console->ctx->current->layout->flags |= (nk_flags)NK_WINDOW_NO_SCROLLBAR;
         }
         else {
-            console->ctx->current->layout->flags &= ~(nk_uint)NK_WINDOW_NO_SCROLLBAR;
+            console->ctx->current->layout->flags &= ~(nk_flags)NK_WINDOW_NO_SCROLLBAR;
         }
     }
 
@@ -1659,7 +1762,7 @@ NK_API void nk_console_add_child(nk_console* parent, nk_console* child) {
 
         // Set the visibility of the child based on whether the tree is expanded.
         if (nk_console_tree_expanded(parent)) child->flags |= NK_CONSOLE_FLAG_VISIBLE;
-        else child->flags &= ~(nk_uint)NK_CONSOLE_FLAG_VISIBLE;
+        else child->flags &= ~(nk_flags)NK_CONSOLE_FLAG_VISIBLE;
 
         // Insert position: immediately after the tree and any previously owned children.
         int widget_index = nk_console_get_widget_index(parent);

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -99,15 +99,19 @@ typedef enum {
     NK_CONSOLE_MESSAGE_POSITION_RIGHT, /** Slide in from the right edge. */
 } nk_console_message_position;
 
+typedef enum {
+    NK_CONSOLE_FLAG_SELECTABLE = NK_FLAG(0), /** Whether or not the widget can be selected. */
+    NK_CONSOLE_FLAG_DISABLED   = NK_FLAG(1), /** Whether or not the widget is currently disabled. */
+    NK_CONSOLE_FLAG_VISIBLE    = NK_FLAG(2), /** When false, the widget will not be displayed. */
+} nk_console_flag;
+
 typedef struct nk_console {
     nk_console_widget_type type;
     const char* label;
     int label_length;
     nk_flags alignment;
 
-    nk_bool selectable; /** Whether or not the widget can be selected. */
-    nk_bool disabled; /** Whether or not the widget is currently disabled. */
-    nk_bool visible; /** When false, the widget will not be displayed. */
+    nk_uint flags; /** NK_CONSOLE_FLAG_SELECTABLE | NK_CONSOLE_FLAG_DISABLED | NK_CONSOLE_FLAG_VISIBLE */
     int columns; /** When set, will determine how many dynamic columns to set to for the active row. */
     int height; /** When set, will determine the height of the row. */
     const char* tooltip; /** Tooltip */
@@ -123,10 +127,20 @@ typedef struct nk_console {
     nk_console_render_event render; /** Render the widget. */
 } nk_console;
 
+typedef enum {
+    NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED    = NK_FLAG(0), /** Whether or not user input has been processed. */
+    NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED = NK_FLAG(1), /** True when the scrollbar is needed to be rendered. */
+    NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED      = NK_FLAG(2), /** True this frame if an axis fired an up event. */
+    NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED    = NK_FLAG(3), /** True this frame if an axis fired a down event. */
+    NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED    = NK_FLAG(4), /** True this frame if an axis fired a left event. */
+    NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED   = NK_FLAG(5), /** True this frame if an axis fired a right event. */
+    NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE    = NK_FLAG(6), /** True when a drag-scroll gesture is in progress. */
+    NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED = NK_FLAG(7), /** True when the drag started from the content area (not scrollbar). */
+} nk_console_top_flag;
+
 typedef struct nk_console_top_data {
     nk_console* active_parent; /** The parent that is currently being displayed. */
-    nk_bool input_processed; /** Whether or not user input has been processed. */
-    nk_bool scrollbar_required; /** True when the scrollbar is needed to be rendered. @see nk_console_render_window() */
+    nk_uint state; /** NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED | NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED | NK_CONSOLE_TOP_FLAG_AXIS_*_FIRED | NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_* */
     nk_console* scroll_to_widget; /** When set by nk_console_navigate_back, the render loop scrolls the window to this widget's bounds. */
 
     /**
@@ -180,13 +194,6 @@ typedef struct nk_console_top_data {
         float hold_timer; /** Total active hold time, drives acceleration. */
     } axis_ud, axis_lr;
 
-    nk_bool axis_up_fired; /** True this frame if an axis fired an up event. */
-    nk_bool axis_down_fired; /** True this frame if an axis fired a down event. */
-    nk_bool axis_left_fired; /** True this frame if an axis fired a left event. */
-    nk_bool axis_right_fired; /** True this frame if an axis fired a right event. */
-
-    nk_bool drag_scroll_active; /** True when a drag-scroll gesture is in progress. */
-    nk_bool drag_scroll_initiated; /** True when the drag started from the content area (not scrollbar). */
     struct nk_vec2 drag_scroll_origin; /** Mouse position when the drag started. */
     nk_uint drag_scroll_start_x; /** Window scroll X at drag start. */
     nk_uint drag_scroll_start_y; /** Window scroll Y at drag start. */
@@ -790,7 +797,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
     }
 
     // Only process an active input once.
-    if (data->input_processed == nk_false) {
+    if (!(data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Page Up
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LB)) {
             int widgetIndex = nk_console_get_widget_index(widget);
@@ -809,7 +816,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
                 nk_console_set_active_widget(target);
                 data->scroll_to_widget = target;
             }
-            data->input_processed = nk_true;
+            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         // Page Down
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RB)) {
@@ -831,7 +838,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
                 nk_console_set_active_widget(target);
                 data->scroll_to_widget = target;
             }
-            data->input_processed = nk_true;
+            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         // Up
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_UP) || (up_held && up_down_repeat_fire)) {
@@ -844,7 +851,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
                     break;
                 }
             }
-            data->input_processed = nk_true;
+            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         // Down
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_DOWN) || (down_held && up_down_repeat_fire)) {
@@ -859,12 +866,12 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
                     }
                 }
             }
-            data->input_processed = nk_true;
+            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         // Back
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_B)) {
             if (nk_console_active_parent(top) == NULL) {
-                data->input_processed = nk_true;
+                data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
                 return;
             }
 
@@ -872,7 +879,7 @@ NK_API void nk_console_check_up_down(nk_console* widget) {
                 nk_console_navigate_back(widget->parent);
             }
 
-            data->input_processed = nk_true;
+            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
     }
 }
@@ -907,7 +914,7 @@ NK_API nk_bool nk_console_selectable(nk_console* widget) {
         return nk_false;
     }
 
-    return widget->selectable && widget->visible && !widget->disabled;
+    return (widget->flags & NK_CONSOLE_FLAG_SELECTABLE) && (widget->flags & NK_CONSOLE_FLAG_VISIBLE) && !(widget->flags & NK_CONSOLE_FLAG_DISABLED);
 }
 
 #ifndef NK_CONSOLE_TOOLTIP_SCROLL_SPEED
@@ -1001,7 +1008,7 @@ static nk_bool nk_console_axis_tick(struct nk_console_axis_channel* ch, float st
  */
 static void nk_console_axis_update(nk_console* console) {
     nk_console_top_data* data = (nk_console_top_data*)console->data;
-    data->axis_up_fired = data->axis_down_fired = data->axis_left_fired = data->axis_right_fired = nk_false;
+    data->state &= ~(nk_uint)(NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED | NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED);
     if (data->gamepads == NULL || console->ctx->delta_time_seconds <= 0) {
         return;
     }
@@ -1031,18 +1038,18 @@ static void nk_console_axis_update(nk_console* console) {
     // Up/Down
     if (nk_console_axis_tick(&data->axis_ud, NK_MAX(up_strength, down_strength), console->ctx->delta_time_seconds)) {
         if (up_strength >= down_strength) {
-            data->axis_up_fired = nk_true;
+            data->state |= NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED;
         }
         else {
-            data->axis_down_fired = nk_true;
+            data->state |= NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED;
         }
     }
     // Left/Right
     if (nk_console_axis_tick(&data->axis_lr, NK_MAX(left_strength, right_strength), console->ctx->delta_time_seconds)) {
         if (left_strength >= right_strength)
-            data->axis_left_fired = nk_true;
+            data->state |= NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED;
         else
-            data->axis_right_fired = nk_true;
+            data->state |= NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED;
     }
 }
 
@@ -1053,32 +1060,33 @@ static void nk_console_window_touch_drag(nk_console* console, nk_console_top_dat
     struct nk_input* in = &console->ctx->input;
     if (nk_window_is_hovered(console->ctx) && nk_input_is_mouse_pressed(in, NK_BUTTON_LEFT)) {
         struct nk_rect content = nk_window_get_content_region(console->ctx);
-        top_data->drag_scroll_initiated = nk_input_is_mouse_hovering_rect(in, content);
-        if (top_data->drag_scroll_initiated) {
+        if (nk_input_is_mouse_hovering_rect(in, content)) top_data->state |= NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
+        else top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
+        if ((top_data->state & NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED)) {
             top_data->drag_scroll_origin = in->mouse.pos;
             nk_window_get_scroll(console->ctx, &top_data->drag_scroll_start_x, &top_data->drag_scroll_start_y);
-            top_data->drag_scroll_active = nk_false;
+            top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
         }
     }
     if (nk_input_is_mouse_down(in, NK_BUTTON_LEFT)) {
-        if (top_data->drag_scroll_initiated) {
+        if ((top_data->state & NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED)) {
             float dy = top_data->drag_scroll_origin.y - in->mouse.pos.y;
             float dx = top_data->drag_scroll_origin.x - in->mouse.pos.x;
-            if (!top_data->drag_scroll_active &&
+            if (!(top_data->state & NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE) &&
                 (dy * dy + dx * dx) > NK_CONSOLE_DRAG_THRESHOLD * NK_CONSOLE_DRAG_THRESHOLD) {
-                top_data->drag_scroll_active = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
             }
-            if (top_data->drag_scroll_active) {
+            if ((top_data->state & NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE)) {
                 nk_uint sx = (nk_uint)NK_CLAMP(0.0f, (float)top_data->drag_scroll_start_x + dx, (float)top_data->drag_scroll_max_x);
                 nk_uint sy = (nk_uint)NK_CLAMP(0.0f, (float)top_data->drag_scroll_start_y + dy, (float)top_data->drag_scroll_max_y);
                 nk_window_set_scroll(console->ctx, sx, sy);
-                top_data->input_processed = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
         }
     }
     else {
-        top_data->drag_scroll_active = nk_false;
-        top_data->drag_scroll_initiated = nk_false;
+        top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_ACTIVE;
+        top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_DRAG_SCROLL_INITIATED;
     }
 }
 
@@ -1146,7 +1154,7 @@ static void nk_console_update_drag_scroll(nk_console* console, nk_console_top_da
  */
 static void nk_console_render_top(nk_console* console) {
     nk_console_top_data* data = (nk_console_top_data*)console->data;
-    data->input_processed = nk_false;
+    data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     nk_console_axis_update(console);
     nk_console_window_touch_drag(console, data);
     nk_console_trigger_event(data->active_parent, NK_CONSOLE_EVENT_PRE_PARENT_RENDER);
@@ -1165,7 +1173,7 @@ static void nk_console_render_top(nk_console* console) {
 }
 
 NK_API void nk_console_render(nk_console* console) {
-    if (console == NULL || console->visible == nk_false) {
+    if (console == NULL || !(console->flags & NK_CONSOLE_FLAG_VISIBLE)) {
         return;
     }
 
@@ -1202,10 +1210,10 @@ NK_API void nk_console_render(nk_console* console) {
         nk_window_get_scroll(console->ctx, &window_scroll_x, &window_scroll_y);
         widget_bounds.x -= (float)window_scroll_x;
         widget_bounds.y -= (float)window_scroll_y;
-        if (top_data->input_processed == nk_false && nk_input_is_mouse_hovering_rect(&console->ctx->input, widget_bounds)) {
+        if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && nk_input_is_mouse_hovering_rect(&console->ctx->input, widget_bounds)) {
             if (nk_console_selectable(console)) {
                 nk_console_set_active_widget(console);
-                top_data->input_processed = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
         }
     }
@@ -1234,7 +1242,7 @@ NK_API nk_console* nk_console_init(struct nk_context* context) {
     console->type = NK_CONSOLE_PARENT;
     console->ctx = context;
     console->alignment = NK_TEXT_ALIGN_CENTERED;
-    console->visible = nk_true;
+    console->flags |= NK_CONSOLE_FLAG_VISIBLE;
 
     nk_console_top_data* data = (nk_console_top_data*)nk_console_malloc(handle, NULL, sizeof(nk_console_top_data));
     nk_zero(data, sizeof(nk_console_top_data));
@@ -1273,7 +1281,7 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
     // Determine if the scrollbar is needed.
     top_data = (nk_console_top_data*)console->data;
     if ((flags & NK_WINDOW_SCROLL_AUTO_HIDE) != 0) {
-        if (top_data->scrollbar_required) {
+        if ((top_data->state & NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED)) {
             flags |= (nk_uint)NK_WINDOW_NO_SCROLLBAR;
         }
         else {
@@ -1288,8 +1296,10 @@ NK_API struct nk_rect nk_console_render_window(nk_console* console, const char* 
 
     // After all elements have been rendered, update the layout flags.
     if ((flags & NK_WINDOW_SCROLL_AUTO_HIDE) != 0) {
-        top_data->scrollbar_required = (console->ctx->current->layout->at_y - console->ctx->current->layout->bounds.y) <= console->ctx->current->layout->bounds.h;
-        if (top_data->scrollbar_required) {
+        if ((console->ctx->current->layout->at_y - console->ctx->current->layout->bounds.y) <= console->ctx->current->layout->bounds.h)
+            top_data->state |= NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
+        else top_data->state &= ~(nk_uint)NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
+        if ((top_data->state & NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED)) {
             console->ctx->current->layout->flags |= (nk_uint)NK_WINDOW_NO_SCROLLBAR;
         }
         else {
@@ -1480,7 +1490,7 @@ NK_API void nk_console_navigate_back(nk_console* leaving_parent) {
     if (leaving_parent == top) {
         // Still trigger the back event if we're trying to leave the top.
         nk_console_trigger_event(leaving_parent, NK_CONSOLE_EVENT_BACK);
-        data->input_processed = nk_true;
+        data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         return;
     }
     nk_console* destination = (leaving_parent->parent != NULL) ? leaving_parent->parent : top;
@@ -1488,7 +1498,7 @@ NK_API void nk_console_navigate_back(nk_console* leaving_parent) {
     nk_console_set_active_widget(leaving_parent);
     if (data != NULL) {
         data->scroll_to_widget = leaving_parent;
-        data->input_processed = nk_true;
+        data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     }
     nk_console_trigger_event(leaving_parent, NK_CONSOLE_EVENT_BACK);
 }
@@ -1584,10 +1594,10 @@ NK_API nk_bool nk_console_button_pushed(nk_console* console, int button) {
 
     // Keyboard/Mouse/Axis
     switch (button) {
-        case NK_GAMEPAD_BUTTON_UP: return data->axis_up_fired || nk_input_is_key_released(&console->ctx->input, NK_KEY_UP);
-        case NK_GAMEPAD_BUTTON_DOWN: return data->axis_down_fired || nk_input_is_key_released(&console->ctx->input, NK_KEY_DOWN);
-        case NK_GAMEPAD_BUTTON_LEFT: return data->axis_left_fired || nk_input_is_key_released(&console->ctx->input, NK_KEY_LEFT);
-        case NK_GAMEPAD_BUTTON_RIGHT: return data->axis_right_fired || nk_input_is_key_released(&console->ctx->input, NK_KEY_RIGHT);
+        case NK_GAMEPAD_BUTTON_UP: return (data->state & NK_CONSOLE_TOP_FLAG_AXIS_UP_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_UP);
+        case NK_GAMEPAD_BUTTON_DOWN: return (data->state & NK_CONSOLE_TOP_FLAG_AXIS_DOWN_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_DOWN);
+        case NK_GAMEPAD_BUTTON_LEFT: return (data->state & NK_CONSOLE_TOP_FLAG_AXIS_LEFT_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_LEFT);
+        case NK_GAMEPAD_BUTTON_RIGHT: return (data->state & NK_CONSOLE_TOP_FLAG_AXIS_RIGHT_FIRED) || nk_input_is_key_released(&console->ctx->input, NK_KEY_RIGHT);
         case NK_GAMEPAD_BUTTON_A: return nk_input_is_key_released(&console->ctx->input, NK_KEY_ENTER);
         case NK_GAMEPAD_BUTTON_B:
             // Escape Key
@@ -1642,7 +1652,8 @@ NK_API void nk_console_add_child(nk_console* parent, nk_console* child) {
         nk_console_tree_data* tree_data = (nk_console_tree_data*)parent->data;
 
         // Set the visibility of the child based on whether the tree is expanded.
-        child->visible = nk_console_tree_expanded(parent);
+        if (nk_console_tree_expanded(parent)) child->flags |= NK_CONSOLE_FLAG_VISIBLE;
+        else child->flags &= ~(nk_uint)NK_CONSOLE_FLAG_VISIBLE;
 
         // Insert position: immediately after the tree and any previously owned children.
         int widget_index = nk_console_get_widget_index(parent);

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -107,7 +107,9 @@ typedef enum {
 
 #define NK_FLAG_ENABLED(flags, flag)  ((flags) & (flag))
 #define NK_FLAG_DISABLED(flags, flag) (!((flags) & (flag)))
-#define NK_FLAG_TOGGLE(flags, flag)   ((flags) ^= (flag))
+#define NK_FLAG_SET(flags, flag)      ((flags) |= (nk_uint)(flag))
+#define NK_FLAG_CLEAR(flags, flag)    ((flags) &= ~(nk_uint)(flag))
+#define NK_FLAG_TOGGLE(flags, flag)   ((flags) ^= (nk_uint)(flag))
 
 typedef struct nk_console {
     nk_console_widget_type type;

--- a/nuklear_console_button.h
+++ b/nuklear_console_button.h
@@ -94,13 +94,13 @@ NK_API struct nk_rect nk_console_button_render(nk_console* console) {
 
     struct nk_rect widget_bounds = nk_layout_widget_bounds(console->ctx);
 
-    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_begin(console->ctx);
     }
 
     // Check the button state.
     nk_bool selected = nk_false;
-    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
+    if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
         selected = nk_true;
     }
 
@@ -174,7 +174,7 @@ NK_API struct nk_rect nk_console_button_render(nk_console* console) {
         }
     }
 
-    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_end(console->ctx);
     }
 

--- a/nuklear_console_button.h
+++ b/nuklear_console_button.h
@@ -100,7 +100,7 @@ NK_API struct nk_rect nk_console_button_render(nk_console* console) {
 
     // Check the button state.
     nk_bool selected = nk_false;
-    if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
+    if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
         selected = nk_true;
     }
 
@@ -164,7 +164,7 @@ NK_API struct nk_rect nk_console_button_render(nk_console* console) {
 
     // Act on the button
     if (selected) {
-        top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+        top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
 
         // Trigger the click event. If no event was invoked, switch the parent.
         if (nk_console_trigger_event(console, NK_CONSOLE_EVENT_CLICKED) == nk_false) {

--- a/nuklear_console_button.h
+++ b/nuklear_console_button.h
@@ -94,13 +94,13 @@ NK_API struct nk_rect nk_console_button_render(nk_console* console) {
 
     struct nk_rect widget_bounds = nk_layout_widget_bounds(console->ctx);
 
-    if (console->disabled) {
+    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_begin(console->ctx);
     }
 
     // Check the button state.
     nk_bool selected = nk_false;
-    if (!console->disabled && nk_console_is_active_widget(console) && !top_data->input_processed && nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
+    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
         selected = nk_true;
     }
 
@@ -164,7 +164,7 @@ NK_API struct nk_rect nk_console_button_render(nk_console* console) {
 
     // Act on the button
     if (selected) {
-        top_data->input_processed = nk_true;
+        top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
 
         // Trigger the click event. If no event was invoked, switch the parent.
         if (nk_console_trigger_event(console, NK_CONSOLE_EVENT_CLICKED) == nk_false) {
@@ -174,7 +174,7 @@ NK_API struct nk_rect nk_console_button_render(nk_console* console) {
         }
     }
 
-    if (console->disabled) {
+    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_end(console->ctx);
     }
 
@@ -198,7 +198,7 @@ NK_API nk_console* nk_console_button(nk_console* parent, const char* text) {
     nk_console* button = nk_console_label(parent, text);
     button->type = NK_CONSOLE_BUTTON;
     button->data = (void*)data;
-    button->selectable = nk_true;
+    button->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     button->columns = 1;
     button->render = nk_console_button_render;
     return button;

--- a/nuklear_console_checkbox.h
+++ b/nuklear_console_checkbox.h
@@ -43,14 +43,14 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
 
     // Allow changing the checkbox value.
     nk_bool active = nk_false;
-    if (!console->disabled && nk_console_is_active_widget(console) && !top_data->input_processed) {
+    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
             if (data->value_bool != NULL) {
                 *data->value_bool = !*data->value_bool;
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
             }
             active = nk_true;
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
             if (data->value_bool != NULL) {
@@ -58,7 +58,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
             }
             active = nk_true;
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
             if (data->value_bool != NULL) {
@@ -66,7 +66,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
             }
             active = nk_true;
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
     }
 
@@ -81,7 +81,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
         }
     }
 
-    if (console->disabled || !nk_console_is_active_widget(console)) {
+    if ((console->flags & NK_CONSOLE_FLAG_DISABLED) || !nk_console_is_active_widget(console)) {
         nk_widget_disable_begin(console->ctx);
     }
 
@@ -99,7 +99,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
         nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
     }
 
-    if (console->disabled || !nk_console_is_active_widget(console)) {
+    if ((console->flags & NK_CONSOLE_FLAG_DISABLED) || !nk_console_is_active_widget(console)) {
         nk_widget_disable_end(console->ctx);
     }
 
@@ -124,7 +124,7 @@ NK_API nk_console* nk_console_checkbox(nk_console* parent, const char* text, nk_
     checkbox->render = nk_console_checkbox_render;
     data->value_bool = active;
     checkbox->type = NK_CONSOLE_CHECKBOX;
-    checkbox->selectable = nk_true;
+    checkbox->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     checkbox->columns = 1;
     checkbox->data = (void*)data;
     return checkbox;

--- a/nuklear_console_checkbox.h
+++ b/nuklear_console_checkbox.h
@@ -43,7 +43,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
 
     // Allow changing the checkbox value.
     nk_bool active = nk_false;
-    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
             if (data->value_bool != NULL) {
                 *data->value_bool = !*data->value_bool;
@@ -81,7 +81,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
         }
     }
 
-    if ((console->flags & NK_CONSOLE_FLAG_DISABLED) || !nk_console_is_active_widget(console)) {
+    if (NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) || !nk_console_is_active_widget(console)) {
         nk_widget_disable_begin(console->ctx);
     }
 
@@ -99,7 +99,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
         nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
     }
 
-    if ((console->flags & NK_CONSOLE_FLAG_DISABLED) || !nk_console_is_active_widget(console)) {
+    if (NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) || !nk_console_is_active_widget(console)) {
         nk_widget_disable_end(console->ctx);
     }
 

--- a/nuklear_console_checkbox.h
+++ b/nuklear_console_checkbox.h
@@ -43,14 +43,14 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
 
     // Allow changing the checkbox value.
     nk_bool active = nk_false;
-    if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
             if (data->value_bool != NULL) {
                 *data->value_bool = !*data->value_bool;
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
             }
             active = nk_true;
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
             if (data->value_bool != NULL) {
@@ -58,7 +58,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
             }
             active = nk_true;
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
             if (data->value_bool != NULL) {
@@ -66,7 +66,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
             }
             active = nk_true;
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
     }
 

--- a/nuklear_console_color.h
+++ b/nuklear_console_color.h
@@ -121,7 +121,7 @@ NK_API nk_console* nk_console_color(nk_console* parent, const char* label, struc
     widget->type = NK_CONSOLE_COLOR;
     widget->columns = label == NULL ? 1 : 2;
     widget->render = nk_console_color_render;
-    widget->selectable = nk_true;
+    widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     widget->data = data;
     nk_console_button_set_symbol(widget, NK_SYMBOL_RECT_SOLID);
 

--- a/nuklear_console_combobox.h
+++ b/nuklear_console_combobox.h
@@ -188,9 +188,9 @@ NK_API struct nk_rect nk_console_combobox_render(nk_console* console) {
     nk_console_layout_widget(console);
 
     // Allow changing the value with left/right
-    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
+    if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && data->selected != NULL && console->children != NULL) {
+        if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && data->selected != NULL && console->children != NULL) {
             nk_bool changed = nk_false;
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT) && *data->selected > 0) {
                 *data->selected = *data->selected - 1;

--- a/nuklear_console_combobox.h
+++ b/nuklear_console_combobox.h
@@ -190,7 +190,7 @@ NK_API struct nk_rect nk_console_combobox_render(nk_console* console) {
     // Allow changing the value with left/right
     if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && data->selected != NULL && console->children != NULL) {
+        if (NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && data->selected != NULL && console->children != NULL) {
             nk_bool changed = nk_false;
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT) && *data->selected > 0) {
                 *data->selected = *data->selected - 1;
@@ -202,7 +202,7 @@ NK_API struct nk_rect nk_console_combobox_render(nk_console* console) {
             }
 
             if (changed) {
-                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
                 console->label = console->children[*data->selected + 1]->label;
                 console->label_length = console->children[*data->selected + 1]->label_length;
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);

--- a/nuklear_console_combobox.h
+++ b/nuklear_console_combobox.h
@@ -163,7 +163,7 @@ NK_API nk_console* nk_console_combobox(nk_console* parent, const char* label, co
     // Set up the combobox
     nk_console* combobox = nk_console_label(parent, label);
     combobox->type = NK_CONSOLE_COMBOBOX;
-    combobox->selectable = nk_true;
+    combobox->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     combobox->columns = label != NULL ? 2 : 1;
     combobox->render = nk_console_combobox_render;
     combobox->data = data;
@@ -188,9 +188,9 @@ NK_API struct nk_rect nk_console_combobox_render(nk_console* console) {
     nk_console_layout_widget(console);
 
     // Allow changing the value with left/right
-    if (!console->disabled && nk_console_is_active_widget(console)) {
+    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (!top_data->input_processed && data->selected != NULL && console->children != NULL) {
+        if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) && data->selected != NULL && console->children != NULL) {
             nk_bool changed = nk_false;
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT) && *data->selected > 0) {
                 *data->selected = *data->selected - 1;
@@ -202,7 +202,7 @@ NK_API struct nk_rect nk_console_combobox_render(nk_console* console) {
             }
 
             if (changed) {
-                top_data->input_processed = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
                 console->label = console->children[*data->selected + 1]->label;
                 console->label_length = console->children[*data->selected + 1]->label_length;
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);

--- a/nuklear_console_file.h
+++ b/nuklear_console_file.h
@@ -856,7 +856,7 @@ NK_API void nk_console_file_refresh(nk_console* widget, void* user_data) {
         if (cvector_empty(data->entries)) {
             nk_console* empty_label = nk_console_label(widget, "[Empty Directory]");
             empty_label->alignment = NK_TEXT_CENTERED;
-            empty_label->disabled = nk_true;
+            empty_label->flags |= NK_CONSOLE_FLAG_DISABLED;
         }
         else {
             for (size_t i = 0; i < cvector_size(data->entries); i++) {
@@ -882,7 +882,7 @@ NK_API void nk_console_file_refresh(nk_console* widget, void* user_data) {
 
     // Go back to the parent widget, and disable the widget.
     if (widget->parent != NULL) {
-        widget->disabled = nk_true;
+        widget->flags |= NK_CONSOLE_FLAG_DISABLED;
         nk_console_set_active_parent(widget->parent);
     }
 #endif
@@ -1136,7 +1136,7 @@ NK_API nk_console* nk_console_file(nk_console* parent, const char* label, char* 
     widget->type = NK_CONSOLE_FILE;
     widget->columns = label == NULL ? 1 : 2;
     widget->render = nk_console_file_render;
-    widget->selectable = nk_true;
+    widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     widget->data = data;
 
     nk_console_add_event(widget, NK_CONSOLE_EVENT_CLICKED, &nk_console_file_event_clicked);

--- a/nuklear_console_image.h
+++ b/nuklear_console_image.h
@@ -79,16 +79,16 @@ NK_API struct nk_rect nk_console_image_render(nk_console* widget) {
     struct nk_rect widget_bounds = nk_layout_widget_bounds(widget->ctx);
 
     // Toggle it as disabled if needed.
-    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED) ||
-        ((widget->flags & NK_CONSOLE_FLAG_SELECTABLE) && nk_console_get_active_widget(widget) != widget)) {
+    if (NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) ||
+        (NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_SELECTABLE) && nk_console_get_active_widget(widget) != widget)) {
         nk_widget_disable_begin(widget->ctx);
     }
 
     nk_image_color(widget->ctx, data->image, data->color);
 
     // Release the disabled state if needed.
-    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED) ||
-        ((widget->flags & NK_CONSOLE_FLAG_SELECTABLE) && nk_console_get_active_widget(widget) != widget)) {
+    if (NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) ||
+        (NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_SELECTABLE) && nk_console_get_active_widget(widget) != widget)) {
         nk_widget_disable_end(widget->ctx);
     }
 

--- a/nuklear_console_image.h
+++ b/nuklear_console_image.h
@@ -79,16 +79,16 @@ NK_API struct nk_rect nk_console_image_render(nk_console* widget) {
     struct nk_rect widget_bounds = nk_layout_widget_bounds(widget->ctx);
 
     // Toggle it as disabled if needed.
-    if (widget->disabled ||
-        (widget->selectable && nk_console_get_active_widget(widget) != widget)) {
+    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED) ||
+        ((widget->flags & NK_CONSOLE_FLAG_SELECTABLE) && nk_console_get_active_widget(widget) != widget)) {
         nk_widget_disable_begin(widget->ctx);
     }
 
     nk_image_color(widget->ctx, data->image, data->color);
 
     // Release the disabled state if needed.
-    if (widget->disabled ||
-        (widget->selectable && nk_console_get_active_widget(widget) != widget)) {
+    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED) ||
+        ((widget->flags & NK_CONSOLE_FLAG_SELECTABLE) && nk_console_get_active_widget(widget) != widget)) {
         nk_widget_disable_end(widget->ctx);
     }
 

--- a/nuklear_console_input.h
+++ b/nuklear_console_input.h
@@ -446,7 +446,7 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
 
     // Check for input.
     nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-    if (top_data->input_processed == nk_false) {
+    if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Keyboard and mouse are checked before the gamepad so that physical
         // keyboard/mouse input wins over a keyboard-backed virtual gamepad
         // (which maps characters such as 'a' or space onto gamepad buttons).
@@ -524,7 +524,7 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
     }
 
     if (finished == nk_true) {
-        top_data->input_processed = nk_true;
+        top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         data->timer = 0.0f;
         nk_console_add_event(console, NK_CONSOLE_EVENT_POST_RENDER_ONCE, &nk_console_button_back);
     }
@@ -724,7 +724,7 @@ NK_API nk_console* nk_console_input(nk_console* parent, const char* label, int g
     widget->type = NK_CONSOLE_INPUT;
     widget->columns = label == NULL ? 1 : 2;
     widget->render = nk_console_input_render;
-    widget->selectable = nk_true;
+    widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     widget->data = data;
 
     active_state = nk_console_label(widget, NULL);

--- a/nuklear_console_input.h
+++ b/nuklear_console_input.h
@@ -446,7 +446,7 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
 
     // Check for input.
     nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-    if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Keyboard and mouse are checked before the gamepad so that physical
         // keyboard/mouse input wins over a keyboard-backed virtual gamepad
         // (which maps characters such as 'a' or space onto gamepad buttons).
@@ -525,7 +525,7 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
     }
 
     if (finished == nk_true) {
-        top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+        top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         data->timer = 0.0f;
         nk_console_add_event(console, NK_CONSOLE_EVENT_POST_RENDER_ONCE, &nk_console_button_back);
     }

--- a/nuklear_console_input.h
+++ b/nuklear_console_input.h
@@ -255,7 +255,7 @@ static nk_bool nk_gamepad_any_button_released(struct nk_gamepads* g, int n, int*
  * @return An nk_console_input_flags bit, or 0 when no active value is set.
  * @see enum nk_console_input_flags
  */
-static nk_uint nk_console_input_active_source(const nk_console_input_data* data) {
+static nk_flags nk_console_input_active_source(const nk_console_input_data* data) {
     if (data == NULL)
         return 0;
     if (data->out_key != NULL && *data->out_key != NK_CONSOLE_KEY_NONE)
@@ -300,7 +300,7 @@ NK_API struct nk_rect nk_console_input_render(nk_console* console) {
     // Determine the display label based on the active output mode. Reset the
     // symbol each frame so a leftover gamepad glyph clears when rebound.
     const char* display_label = "<None>";
-    nk_uint active = nk_console_input_active_source(data);
+    nk_flags active = nk_console_input_active_source(data);
     nk_console_button_set_symbol(console, NK_SYMBOL_NONE);
     if (active == NK_CONSOLE_INPUT_FLAG_KEY) {
         display_label = nk_console_input_key_name(*data->out_key);
@@ -398,7 +398,7 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
 
     // Handle the timeout: apply the default for whichever source is active.
     if (data->timer >= NK_CONSOLE_INPUT_TIMER) {
-        nk_uint source = nk_console_input_active_source(data);
+        nk_flags source = nk_console_input_active_source(data);
         if (source == NK_CONSOLE_INPUT_FLAG_GAMEPAD) {
             *data->out_gamepad_button = data->default_gamepad_button;
             if (data->out_key != NULL) *data->out_key = NK_CONSOLE_KEY_NONE;
@@ -423,7 +423,7 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
 
     // Blinking prompt label listing each accepted input source.
     if (((int)(data->timer * 2)) % 2 == 0) {
-        nk_uint source_flags = 0;
+        nk_flags source_flags = 0;
         const char* prompt;
         if (data->out_gamepad_button != NULL) source_flags |= NK_CONSOLE_INPUT_FLAG_GAMEPAD;
         if (data->out_key != NULL)            source_flags |= NK_CONSOLE_INPUT_FLAG_KEY;

--- a/nuklear_console_input.h
+++ b/nuklear_console_input.h
@@ -446,7 +446,7 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
 
     // Check for input.
     nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-    if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Keyboard and mouse are checked before the gamepad so that physical
         // keyboard/mouse input wins over a keyboard-backed virtual gamepad
         // (which maps characters such as 'a' or space onto gamepad buttons).

--- a/nuklear_console_knob.h
+++ b/nuklear_console_knob.h
@@ -56,7 +56,7 @@ NK_API nk_console* nk_console_knob_int(nk_console* parent, const char* label, in
     nk_console* widget = nk_console_label(parent, label);
     widget->render = &nk_console_property_render;
     widget->type = NK_CONSOLE_KNOB_INT;
-    widget->selectable = nk_true;
+    widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     widget->data = (void*)data;
     widget->columns = label != NULL ? 2 : 1;
 

--- a/nuklear_console_label.h
+++ b/nuklear_console_label.h
@@ -32,12 +32,12 @@ NK_API struct nk_rect nk_console_label_render(nk_console* widget) {
     nk_console_layout_widget(widget);
 
     nk_bool selected = nk_false;
-    if (!widget->disabled && widget->selectable) {
+    if (!(widget->flags & NK_CONSOLE_FLAG_DISABLED) && (widget->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
         selected = nk_console_is_active_widget(widget);
     }
 
     // Toggle it as disabled if needed.
-    if (widget->disabled || (widget->selectable && !selected)) {
+    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED) || ((widget->flags & NK_CONSOLE_FLAG_SELECTABLE) && !selected)) {
         nk_widget_disable_begin(widget->ctx);
     }
 
@@ -50,7 +50,7 @@ NK_API struct nk_rect nk_console_label_render(nk_console* widget) {
     }
 
     // Release the disabled state if needed.
-    if (widget->disabled || (widget->selectable && !selected)) {
+    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED) || ((widget->flags & NK_CONSOLE_FLAG_SELECTABLE) && !selected)) {
         nk_widget_disable_end(widget->ctx);
     }
 
@@ -87,7 +87,7 @@ NK_API nk_console* nk_console_label(nk_console* parent, const char* text) {
     label->alignment = NK_TEXT_LEFT;
     label->columns = 1;
     label->render = nk_console_label_render;
-    label->visible = nk_true;
+    label->flags |= NK_CONSOLE_FLAG_VISIBLE;
     nk_console_add_child(parent, label);
     return label;
 }

--- a/nuklear_console_label.h
+++ b/nuklear_console_label.h
@@ -32,12 +32,12 @@ NK_API struct nk_rect nk_console_label_render(nk_console* widget) {
     nk_console_layout_widget(widget);
 
     nk_bool selected = nk_false;
-    if (!(widget->flags & NK_CONSOLE_FLAG_DISABLED) && (widget->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
+    if (NK_FLAG_DISABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) && NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_SELECTABLE)) {
         selected = nk_console_is_active_widget(widget);
     }
 
     // Toggle it as disabled if needed.
-    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED) || ((widget->flags & NK_CONSOLE_FLAG_SELECTABLE) && !selected)) {
+    if (NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) || (NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_SELECTABLE) && !selected)) {
         nk_widget_disable_begin(widget->ctx);
     }
 
@@ -50,7 +50,7 @@ NK_API struct nk_rect nk_console_label_render(nk_console* widget) {
     }
 
     // Release the disabled state if needed.
-    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED) || ((widget->flags & NK_CONSOLE_FLAG_SELECTABLE) && !selected)) {
+    if (NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) || (NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_SELECTABLE) && !selected)) {
         nk_widget_disable_end(widget->ctx);
     }
 

--- a/nuklear_console_list_view.h
+++ b/nuklear_console_list_view.h
@@ -170,12 +170,12 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
     struct nk_rect widget_bounds = nk_layout_widget_bounds(top->ctx);
     widget_bounds.h = row_height * (float)data->rows_visible;
 
-    if (widget->disabled) {
+    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_begin(top->ctx);
     }
 
     // Handle keyboard/gamepad navigation.
-    if (is_active && !top_data->input_processed) {
+    if (is_active && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Hold-to-accelerate timers - mirrors nk_console_check_up_down.
         nk_bool up_held = nk_console_button_down(top, NK_GAMEPAD_BUTTON_UP);
         nk_bool down_held = nk_console_button_down(top, NK_GAMEPAD_BUTTON_DOWN);
@@ -206,7 +206,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     data->_scroll_y = new_scroll;
                 }
             }
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RB) || nk_input_is_key_pressed(&top->ctx->input, NK_KEY_SCROLL_DOWN)) {
             // Page down: jump selection down by rows_visible items.
@@ -224,7 +224,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     }
                 }
             }
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_UP) || (up_held && repeat_fire)) {
             if (data->selected > 0) {
@@ -247,7 +247,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     }
                 }
             }
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_DOWN) || (down_held && repeat_fire)) {
             if (data->row_count > 0 && data->selected < data->row_count - 1) {
@@ -280,7 +280,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     }
                 }
             }
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
             // Move focus to the previous sibling widget.
@@ -293,7 +293,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     break;
                 }
             }
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
             // Move focus to the next sibling widget.
@@ -307,17 +307,17 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     break;
                 }
             }
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
-        else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A) && !widget->disabled) {
+        else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A) && !(widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
             nk_console_trigger_event(widget, NK_CONSOLE_EVENT_CLICKED);
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_B)) {
             if (widget->parent != NULL) {
                 nk_console_navigate_back(widget->parent);
             }
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
     }
 
@@ -336,7 +336,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
             }
 
             // Mouse Selection
-            if (nk_input_is_mouse_moved(&top->ctx->input) && nk_widget_is_hovered(top->ctx) && !widget->disabled) {
+            if (nk_input_is_mouse_moved(&top->ctx->input) && nk_widget_is_hovered(top->ctx) && !(widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
                 data->selected = (nk_uint)(data->view.begin + i);
                 nk_console_set_active_widget(widget);
             }
@@ -358,9 +358,9 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                 top->ctx->style.button.text_normal = saved_text;
             }
 
-            if (mouse_clicked && top_data->input_processed == nk_false) {
+            if (mouse_clicked && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
                 data->selected = (nk_uint)(data->view.begin + i);
-                top_data->input_processed = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
                 nk_console_trigger_event(widget, NK_CONSOLE_EVENT_CLICKED);
             }
         }
@@ -372,7 +372,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
         }
     }
 
-    if (widget->disabled) {
+    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_end(top->ctx);
     }
 
@@ -405,7 +405,7 @@ NK_API nk_console* nk_console_list_view(nk_console* parent, const char* id, int 
         return NULL;
     }
 
-    widget->selectable = nk_true;
+    widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     widget->type = NK_CONSOLE_LIST_VIEW;
     widget->render = &nk_console_list_view_render;
     widget->data = data;

--- a/nuklear_console_list_view.h
+++ b/nuklear_console_list_view.h
@@ -175,7 +175,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
     }
 
     // Handle keyboard/gamepad navigation.
-    if (is_active && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (is_active && NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Hold-to-accelerate timers - mirrors nk_console_check_up_down.
         nk_bool up_held = nk_console_button_down(top, NK_GAMEPAD_BUTTON_UP);
         nk_bool down_held = nk_console_button_down(top, NK_GAMEPAD_BUTTON_DOWN);
@@ -206,7 +206,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     data->_scroll_y = new_scroll;
                 }
             }
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RB) || nk_input_is_key_pressed(&top->ctx->input, NK_KEY_SCROLL_DOWN)) {
             // Page down: jump selection down by rows_visible items.
@@ -224,7 +224,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     }
                 }
             }
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_UP) || (up_held && repeat_fire)) {
             if (data->selected > 0) {
@@ -247,7 +247,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     }
                 }
             }
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_DOWN) || (down_held && repeat_fire)) {
             if (data->row_count > 0 && data->selected < data->row_count - 1) {
@@ -280,7 +280,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     }
                 }
             }
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
             // Move focus to the previous sibling widget.
@@ -293,7 +293,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     break;
                 }
             }
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
             // Move focus to the next sibling widget.
@@ -307,17 +307,17 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                     break;
                 }
             }
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A) && NK_FLAG_DISABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED)) {
             nk_console_trigger_event(widget, NK_CONSOLE_EVENT_CLICKED);
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
         else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_B)) {
             if (widget->parent != NULL) {
                 nk_console_navigate_back(widget->parent);
             }
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
     }
 
@@ -358,9 +358,9 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                 top->ctx->style.button.text_normal = saved_text;
             }
 
-            if (mouse_clicked && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+            if (mouse_clicked && NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
                 data->selected = (nk_uint)(data->view.begin + i);
-                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
                 nk_console_trigger_event(widget, NK_CONSOLE_EVENT_CLICKED);
             }
         }

--- a/nuklear_console_list_view.h
+++ b/nuklear_console_list_view.h
@@ -170,12 +170,12 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
     struct nk_rect widget_bounds = nk_layout_widget_bounds(top->ctx);
     widget_bounds.h = row_height * (float)data->rows_visible;
 
-    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_begin(top->ctx);
     }
 
     // Handle keyboard/gamepad navigation.
-    if (is_active && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (is_active && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Hold-to-accelerate timers - mirrors nk_console_check_up_down.
         nk_bool up_held = nk_console_button_down(top, NK_GAMEPAD_BUTTON_UP);
         nk_bool down_held = nk_console_button_down(top, NK_GAMEPAD_BUTTON_DOWN);
@@ -309,7 +309,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
             }
             top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
-        else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A) && !(widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
+        else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A) && NK_FLAG_DISABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED)) {
             nk_console_trigger_event(widget, NK_CONSOLE_EVENT_CLICKED);
             top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
         }
@@ -336,7 +336,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
             }
 
             // Mouse Selection
-            if (nk_input_is_mouse_moved(&top->ctx->input) && nk_widget_is_hovered(top->ctx) && !(widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
+            if (nk_input_is_mouse_moved(&top->ctx->input) && nk_widget_is_hovered(top->ctx) && NK_FLAG_DISABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED)) {
                 data->selected = (nk_uint)(data->view.begin + i);
                 nk_console_set_active_widget(widget);
             }
@@ -358,7 +358,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
                 top->ctx->style.button.text_normal = saved_text;
             }
 
-            if (mouse_clicked && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+            if (mouse_clicked && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
                 data->selected = (nk_uint)(data->view.begin + i);
                 top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
                 nk_console_trigger_event(widget, NK_CONSOLE_EVENT_CLICKED);
@@ -372,7 +372,7 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
         }
     }
 
-    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_end(top->ctx);
     }
 

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -199,7 +199,7 @@ NK_API void nk_console_render_message(nk_console* console) {
         it->duration -= console->ctx->delta_time_seconds;
     }
     else if (nk_console_button_pushed(console, NK_GAMEPAD_BUTTON_B)) {
-        data->input_processed = nk_true;
+        NK_FLAG_SET(data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED);
         it->duration = 0.0f;
     }
 

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -199,7 +199,7 @@ NK_API void nk_console_render_message(nk_console* console) {
         it->duration -= console->ctx->delta_time_seconds;
     }
     else if (nk_console_button_pushed(console, NK_GAMEPAD_BUTTON_B)) {
-        NK_FLAG_SET(data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED);
+        NK_FLAG_SET(data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED);
         it->duration = 0.0f;
     }
 

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -216,7 +216,7 @@ NK_API void nk_console_render_message(nk_console* console) {
         }
         // If animations arn't an option, allow dismissing the message.
         else if (nk_console_button_pushed(console, NK_GAMEPAD_BUTTON_B)) {
-            data->input_processed = nk_true;
+            data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             it->duration = 0.0f;
         }
 

--- a/nuklear_console_progress.h
+++ b/nuklear_console_progress.h
@@ -82,14 +82,14 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
     nk_bool active = nk_false;
     if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+        if (NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
                 if (data->value_size != NULL && *data->value_size > 0) {
                     *data->value_size = *data->value_size - 1;
                     nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
                 }
                 active = nk_true;
-                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
             else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
                 if (data->value_size != NULL && *data->value_size < data->max_size) {
@@ -97,7 +97,7 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
                     nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
                 }
                 active = nk_true;
-                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
         }
     }

--- a/nuklear_console_progress.h
+++ b/nuklear_console_progress.h
@@ -80,9 +80,9 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
 
     // Allow changing the value.
     nk_bool active = nk_false;
-    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
+    if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+        if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
                 if (data->value_size != NULL && *data->value_size > 0) {
                     *data->value_size = *data->value_size - 1;
@@ -115,7 +115,7 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
 
     struct nk_rect widget_bounds = nk_layout_widget_bounds(console->ctx);
 
-    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_begin(console->ctx);
     }
 
@@ -142,7 +142,7 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
     console->ctx->style.progress.cursor_hover = cursor_hover;
     console->ctx->style.progress.cursor_active = cursor_active;
 
-    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_end(console->ctx);
     }
 

--- a/nuklear_console_progress.h
+++ b/nuklear_console_progress.h
@@ -42,7 +42,7 @@ NK_API nk_console* nk_console_progress(nk_console* parent, const char* text, nk_
     nk_console* progress = nk_console_label(parent, text);
     progress->render = nk_console_progress_render;
     progress->type = NK_CONSOLE_PROGRESS;
-    progress->selectable = nk_true;
+    progress->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     data->value_size = current;
     data->max_size = max;
     progress->columns = text != NULL ? 2 : 1;
@@ -80,16 +80,16 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
 
     // Allow changing the value.
     nk_bool active = nk_false;
-    if (!console->disabled && nk_console_is_active_widget(console)) {
+    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (!top_data->input_processed) {
+        if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
                 if (data->value_size != NULL && *data->value_size > 0) {
                     *data->value_size = *data->value_size - 1;
                     nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
                 }
                 active = nk_true;
-                top_data->input_processed = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
             else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
                 if (data->value_size != NULL && *data->value_size < data->max_size) {
@@ -97,7 +97,7 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
                     nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
                 }
                 active = nk_true;
-                top_data->input_processed = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
         }
     }
@@ -115,7 +115,7 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
 
     struct nk_rect widget_bounds = nk_layout_widget_bounds(console->ctx);
 
-    if (console->disabled) {
+    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_begin(console->ctx);
     }
 
@@ -142,7 +142,7 @@ NK_API struct nk_rect nk_console_progress_render(nk_console* console) {
     console->ctx->style.progress.cursor_hover = cursor_hover;
     console->ctx->style.progress.cursor_active = cursor_active;
 
-    if (console->disabled) {
+    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_end(console->ctx);
     }
 

--- a/nuklear_console_property.h
+++ b/nuklear_console_property.h
@@ -75,9 +75,9 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
     nk_console* top = nk_console_get_top(console);
 
     // Allow changing the value with left/right
-    if (!console->disabled && nk_console_is_active_widget(console)) {
+    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (!top_data->input_processed) {
+        if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
                 switch (console->type) {
                     case NK_CONSOLE_SLIDER_INT:
@@ -101,7 +101,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
                         break;
                 }
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
-                top_data->input_processed = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
             else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
                 switch (console->type) {
@@ -126,7 +126,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
                         break;
                 }
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
-                top_data->input_processed = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
         }
     }
@@ -165,7 +165,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
 
     struct nk_rect widget_bounds = nk_layout_widget_bounds(console->ctx);
 
-    if (console->disabled) {
+    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_begin(console->ctx);
     }
 
@@ -235,7 +235,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
         console->ctx->style.knob.border_color = border_color;
     }
 
-    if (console->disabled) {
+    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_end(console->ctx);
     }
 
@@ -261,7 +261,7 @@ NK_API nk_console* nk_console_property_int(nk_console* parent, const char* label
     nk_console* widget = nk_console_label(parent, label);
     widget->render = &nk_console_property_render;
     widget->type = NK_CONSOLE_PROPERTY_INT;
-    widget->selectable = nk_true;
+    widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     widget->data = (void*)data;
     widget->columns = label != NULL ? 2 : 1;
 

--- a/nuklear_console_property.h
+++ b/nuklear_console_property.h
@@ -77,7 +77,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
     // Allow changing the value with left/right
     if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+        if (NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
                 switch (console->type) {
                     case NK_CONSOLE_SLIDER_INT:
@@ -101,7 +101,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
                         break;
                 }
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
-                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
             else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
                 switch (console->type) {
@@ -126,7 +126,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
                         break;
                 }
                 nk_console_trigger_event(console, NK_CONSOLE_EVENT_CHANGED);
-                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
         }
     }

--- a/nuklear_console_property.h
+++ b/nuklear_console_property.h
@@ -75,9 +75,9 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
     nk_console* top = nk_console_get_top(console);
 
     // Allow changing the value with left/right
-    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
+    if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console)) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+        if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
                 switch (console->type) {
                     case NK_CONSOLE_SLIDER_INT:
@@ -165,7 +165,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
 
     struct nk_rect widget_bounds = nk_layout_widget_bounds(console->ctx);
 
-    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_begin(console->ctx);
     }
 
@@ -235,7 +235,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
         console->ctx->style.knob.border_color = border_color;
     }
 
-    if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_end(console->ctx);
     }
 

--- a/nuklear_console_radio.h
+++ b/nuklear_console_radio.h
@@ -127,7 +127,7 @@ NK_API struct nk_rect nk_console_radio_render(nk_console* widget) {
     nk_bool selected = nk_console_radio_is_selected(widget);
 
     // Allow changing the radio value.
-    if (active && !selected && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (active && !selected && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
             *data->selected = index;
             selected = nk_true;
@@ -137,7 +137,7 @@ NK_API struct nk_rect nk_console_radio_render(nk_console* widget) {
     }
 
     // Release the disabled state if needed.
-    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_begin(widget->ctx);
     }
 
@@ -198,7 +198,7 @@ NK_API struct nk_rect nk_console_radio_render(nk_console* widget) {
     widget->ctx->style.option.normal = style;
 
     // Release the disabled state if needed.
-    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_end(widget->ctx);
     }
 

--- a/nuklear_console_radio.h
+++ b/nuklear_console_radio.h
@@ -127,11 +127,11 @@ NK_API struct nk_rect nk_console_radio_render(nk_console* widget) {
     nk_bool selected = nk_console_radio_is_selected(widget);
 
     // Allow changing the radio value.
-    if (active && !selected && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (active && !selected && NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
             *data->selected = index;
             selected = nk_true;
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             nk_console_trigger_event(widget, NK_CONSOLE_EVENT_CLICKED);
         }
     }
@@ -191,7 +191,7 @@ NK_API struct nk_rect nk_console_radio_render(nk_console* widget) {
     if (radio_active == nk_true && radio_active != selected) {
         *data->selected = index;
         nk_console_trigger_event(widget, NK_CONSOLE_EVENT_CLICKED);
-        top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+        top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     }
 
     // Restore styles

--- a/nuklear_console_radio.h
+++ b/nuklear_console_radio.h
@@ -127,17 +127,17 @@ NK_API struct nk_rect nk_console_radio_render(nk_console* widget) {
     nk_bool selected = nk_console_radio_is_selected(widget);
 
     // Allow changing the radio value.
-    if (active && !selected && !top_data->input_processed) {
+    if (active && !selected && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_A)) {
             *data->selected = index;
             selected = nk_true;
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             nk_console_trigger_event(widget, NK_CONSOLE_EVENT_CLICKED);
         }
     }
 
     // Release the disabled state if needed.
-    if (widget->disabled) {
+    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_begin(widget->ctx);
     }
 
@@ -191,14 +191,14 @@ NK_API struct nk_rect nk_console_radio_render(nk_console* widget) {
     if (radio_active == nk_true && radio_active != selected) {
         *data->selected = index;
         nk_console_trigger_event(widget, NK_CONSOLE_EVENT_CLICKED);
-        top_data->input_processed = nk_true;
+        top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     }
 
     // Restore styles
     widget->ctx->style.option.normal = style;
 
     // Release the disabled state if needed.
-    if (widget->disabled) {
+    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_end(widget->ctx);
     }
 
@@ -230,7 +230,7 @@ NK_API nk_console* nk_console_radio(nk_console* parent, const char* label, int* 
 
     nk_console* widget = nk_console_label(parent, label);
     widget->type = NK_CONSOLE_RADIO;
-    widget->selectable = nk_true;
+    widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     widget->columns = 1;
     widget->data = data;
     widget->render = nk_console_radio_render;

--- a/nuklear_console_row.h
+++ b/nuklear_console_row.h
@@ -116,7 +116,7 @@ NK_API nk_console* nk_console_row_begin(nk_console* parent) {
     row->type = NK_CONSOLE_ROW;
     row->render = nk_console_row_render;
     row->columns = 0;
-    row->flags &= ~(nk_uint)NK_CONSOLE_FLAG_SELECTABLE;
+    row->flags &= ~(nk_flags)NK_CONSOLE_FLAG_SELECTABLE;
     return row;
 }
 
@@ -129,7 +129,7 @@ NK_API void nk_console_row_end(nk_console* row) {
 
     // Set up the row data based on the available children.
     row->columns = 0;
-    row->flags &= ~(nk_uint)NK_CONSOLE_FLAG_SELECTABLE;
+    row->flags &= ~(nk_flags)NK_CONSOLE_FLAG_SELECTABLE;
     row->height = 0;
     int numChildren = (int)cvector_size(row->children);
     for (int i = 0; i < numChildren; ++i) {
@@ -269,7 +269,7 @@ NK_API struct nk_rect nk_console_row_render(nk_console* console) {
                 nk_bool child_disabled = NK_FLAG_ENABLED(child->flags, NK_CONSOLE_FLAG_DISABLED);
                 child->flags |= NK_CONSOLE_FLAG_DISABLED;
                 child->render(child);
-                if (!child_disabled) child->flags &= ~(nk_uint)NK_CONSOLE_FLAG_DISABLED;
+                if (!child_disabled) child->flags &= ~(nk_flags)NK_CONSOLE_FLAG_DISABLED;
             }
             else {
                 child->render(child);

--- a/nuklear_console_row.h
+++ b/nuklear_console_row.h
@@ -68,7 +68,7 @@ static int nk_console_row_next_selectable_child(nk_console* row, int direction) 
     nk_console_row_data* data = (nk_console_row_data*)row->data;
     int numChildren = (int)cvector_size(row->children);
     for (int i = data->activeChild + direction; i >= 0 && i < numChildren; i += direction) {
-        if (row->children[i]->selectable) {
+        if (row->children[i]->flags & NK_CONSOLE_FLAG_SELECTABLE) {
             return i;
         }
     }
@@ -91,11 +91,11 @@ static nk_bool nk_console_row_pick_nearest_selectable_child(nk_console* row) {
     nk_console_row_data* data = (nk_console_row_data*)row->data;
     int amount = (int)cvector_size(row->children);
     for (int i = 1; i < amount; ++i) {
-        if (data->activeChild + i < amount && row->children[data->activeChild + i]->selectable) {
+        if (data->activeChild + i < amount && (row->children[data->activeChild + i]->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
             data->activeChild += i;
             return nk_true;
         }
-        if (data->activeChild - i >= 0 && row->children[data->activeChild - i]->selectable) {
+        if (data->activeChild - i >= 0 && (row->children[data->activeChild - i]->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
             data->activeChild -= i;
             return nk_true;
         }
@@ -116,7 +116,7 @@ NK_API nk_console* nk_console_row_begin(nk_console* parent) {
     row->type = NK_CONSOLE_ROW;
     row->render = nk_console_row_render;
     row->columns = 0;
-    row->selectable = nk_false;
+    row->flags &= ~(nk_uint)NK_CONSOLE_FLAG_SELECTABLE;
     return row;
 }
 
@@ -129,14 +129,14 @@ NK_API void nk_console_row_end(nk_console* row) {
 
     // Set up the row data based on the available children.
     row->columns = 0;
-    row->selectable = nk_false;
+    row->flags &= ~(nk_uint)NK_CONSOLE_FLAG_SELECTABLE;
     row->height = 0;
     int numChildren = (int)cvector_size(row->children);
     for (int i = 0; i < numChildren; ++i) {
         nk_console* child = row->children[i];
 
         // This row is selectable if there's at least one selectable child.
-        row->selectable |= child->selectable;
+        if (child->flags & NK_CONSOLE_FLAG_SELECTABLE) row->flags |= NK_CONSOLE_FLAG_SELECTABLE;
 
         // The row's height is taken from the tallest child.
         if (child->height > row->height) {
@@ -148,7 +148,7 @@ NK_API void nk_console_row_end(nk_console* row) {
     }
 
     // Make sure we start on a selectable child by default.
-    if (!active_child->selectable) {
+    if (!(active_child->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
         nk_console_row_pick_nearest_selectable_child(row);
     }
 
@@ -159,19 +159,19 @@ NK_API void nk_console_row_end(nk_console* row) {
 static void nk_console_row_check_left_right(nk_console* row, nk_console* top) {
     nk_console_row_data* data = (nk_console_row_data*)row->data;
     nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-    if (top_data->input_processed) {
+    if ((top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         return;
     }
 
     // Left
     if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
         data->activeChild = nk_console_row_next_selectable_child(row, -1);
-        top_data->input_processed = nk_true;
+        top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     }
     // Right
     else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
         data->activeChild = nk_console_row_next_selectable_child(row, 1);
-        top_data->input_processed = nk_true;
+        top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     }
 }
 
@@ -192,7 +192,7 @@ NK_API struct nk_rect nk_console_row_render(nk_console* console) {
     // Consume mouse movement before children have a chance to.
     int numChildren = (int)cvector_size(console->children);
     struct nk_input* input = &console->ctx->input;
-    if (console->selectable && top_data->input_processed == nk_false &&
+    if ((console->flags & NK_CONSOLE_FLAG_SELECTABLE) && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) &&
         widget_bounds.w > 0 && nk_input_is_mouse_moved(input) &&
         nk_input_is_mouse_hovering_rect(input, widget_bounds)) {
         // First, make sure that the active widget is the row.
@@ -216,7 +216,7 @@ NK_API struct nk_rect nk_console_row_render(nk_console* console) {
         }
 
         // Ensure the new active child is actually selectable.
-        if (!nk_console_row_active_child(console)->selectable) {
+        if (!(nk_console_row_active_child(console)->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
             nk_console_row_pick_nearest_selectable_child(console);
         }
     }
@@ -249,27 +249,27 @@ NK_API struct nk_rect nk_console_row_render(nk_console* console) {
 
             // Ensure we switched to a selectable child.
             nk_console* new_active_child = nk_console_row_active_child(active);
-            if (new_active_child != NULL && !new_active_child->selectable) {
+            if (new_active_child != NULL && !(new_active_child->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
                 nk_console_row_pick_nearest_selectable_child(active);
             }
         }
     }
 
     // Set the active widget to the active child of the row.
-    if (!console->disabled && nk_console_is_active_widget(console) && numChildren > 0) {
+    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && numChildren > 0) {
         console->activeWidget = nk_console_row_active_child(console);
     }
 
     // Render all the children
     for (int i = 0; i < numChildren; ++i) {
         nk_console* child = console->children[i];
-        if (child->render != NULL && child->visible == nk_true) {
+        if (child->render != NULL && (child->flags & NK_CONSOLE_FLAG_VISIBLE)) {
             // If the row is disabled, then temporarily disable the child when rendering.
-            if (console->disabled) {
-                nk_bool child_disabled = child->disabled;
-                child->disabled = nk_true;
+            if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
+                nk_bool child_disabled = (child->flags & NK_CONSOLE_FLAG_DISABLED);
+                child->flags |= NK_CONSOLE_FLAG_DISABLED;
                 child->render(child);
-                child->disabled = child_disabled;
+                if (!child_disabled) child->flags &= ~(nk_uint)NK_CONSOLE_FLAG_DISABLED;
             }
             else {
                 child->render(child);

--- a/nuklear_console_row.h
+++ b/nuklear_console_row.h
@@ -159,19 +159,19 @@ NK_API void nk_console_row_end(nk_console* row) {
 static void nk_console_row_check_left_right(nk_console* row, nk_console* top) {
     nk_console_row_data* data = (nk_console_row_data*)row->data;
     nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-    if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) {
+    if NK_FLAG_ENABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) {
         return;
     }
 
     // Left
     if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT)) {
         data->activeChild = nk_console_row_next_selectable_child(row, -1);
-        top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+        top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     }
     // Right
     else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT)) {
         data->activeChild = nk_console_row_next_selectable_child(row, 1);
-        top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+        top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
     }
 }
 
@@ -192,7 +192,7 @@ NK_API struct nk_rect nk_console_row_render(nk_console* console) {
     // Consume mouse movement before children have a chance to.
     int numChildren = (int)cvector_size(console->children);
     struct nk_input* input = &console->ctx->input;
-    if (NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_SELECTABLE) && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) &&
+    if (NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_SELECTABLE) && NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) &&
         widget_bounds.w > 0 && nk_input_is_mouse_moved(input) &&
         nk_input_is_mouse_hovering_rect(input, widget_bounds)) {
         // First, make sure that the active widget is the row.

--- a/nuklear_console_row.h
+++ b/nuklear_console_row.h
@@ -68,7 +68,7 @@ static int nk_console_row_next_selectable_child(nk_console* row, int direction) 
     nk_console_row_data* data = (nk_console_row_data*)row->data;
     int numChildren = (int)cvector_size(row->children);
     for (int i = data->activeChild + direction; i >= 0 && i < numChildren; i += direction) {
-        if (row->children[i]->flags & NK_CONSOLE_FLAG_SELECTABLE) {
+        if (NK_FLAG_ENABLED(row->children[i]->flags, NK_CONSOLE_FLAG_SELECTABLE)) {
             return i;
         }
     }
@@ -91,11 +91,11 @@ static nk_bool nk_console_row_pick_nearest_selectable_child(nk_console* row) {
     nk_console_row_data* data = (nk_console_row_data*)row->data;
     int amount = (int)cvector_size(row->children);
     for (int i = 1; i < amount; ++i) {
-        if (data->activeChild + i < amount && (row->children[data->activeChild + i]->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
+        if (data->activeChild + i < amount && NK_FLAG_ENABLED(row->children[data->activeChild + i]->flags, NK_CONSOLE_FLAG_SELECTABLE)) {
             data->activeChild += i;
             return nk_true;
         }
-        if (data->activeChild - i >= 0 && (row->children[data->activeChild - i]->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
+        if (data->activeChild - i >= 0 && NK_FLAG_ENABLED(row->children[data->activeChild - i]->flags, NK_CONSOLE_FLAG_SELECTABLE)) {
             data->activeChild -= i;
             return nk_true;
         }
@@ -136,7 +136,7 @@ NK_API void nk_console_row_end(nk_console* row) {
         nk_console* child = row->children[i];
 
         // This row is selectable if there's at least one selectable child.
-        if (child->flags & NK_CONSOLE_FLAG_SELECTABLE) row->flags |= NK_CONSOLE_FLAG_SELECTABLE;
+        if NK_FLAG_ENABLED(child->flags, NK_CONSOLE_FLAG_SELECTABLE) row->flags |= NK_CONSOLE_FLAG_SELECTABLE;
 
         // The row's height is taken from the tallest child.
         if (child->height > row->height) {
@@ -148,7 +148,7 @@ NK_API void nk_console_row_end(nk_console* row) {
     }
 
     // Make sure we start on a selectable child by default.
-    if (!(active_child->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
+    if (NK_FLAG_DISABLED(active_child->flags, NK_CONSOLE_FLAG_SELECTABLE)) {
         nk_console_row_pick_nearest_selectable_child(row);
     }
 
@@ -159,7 +159,7 @@ NK_API void nk_console_row_end(nk_console* row) {
 static void nk_console_row_check_left_right(nk_console* row, nk_console* top) {
     nk_console_row_data* data = (nk_console_row_data*)row->data;
     nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-    if ((top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if NK_FLAG_ENABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) {
         return;
     }
 
@@ -192,7 +192,7 @@ NK_API struct nk_rect nk_console_row_render(nk_console* console) {
     // Consume mouse movement before children have a chance to.
     int numChildren = (int)cvector_size(console->children);
     struct nk_input* input = &console->ctx->input;
-    if ((console->flags & NK_CONSOLE_FLAG_SELECTABLE) && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) &&
+    if (NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_SELECTABLE) && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED) &&
         widget_bounds.w > 0 && nk_input_is_mouse_moved(input) &&
         nk_input_is_mouse_hovering_rect(input, widget_bounds)) {
         // First, make sure that the active widget is the row.
@@ -216,7 +216,7 @@ NK_API struct nk_rect nk_console_row_render(nk_console* console) {
         }
 
         // Ensure the new active child is actually selectable.
-        if (!(nk_console_row_active_child(console)->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
+        if (NK_FLAG_DISABLED(nk_console_row_active_child(console)->flags, NK_CONSOLE_FLAG_SELECTABLE)) {
             nk_console_row_pick_nearest_selectable_child(console);
         }
     }
@@ -249,24 +249,24 @@ NK_API struct nk_rect nk_console_row_render(nk_console* console) {
 
             // Ensure we switched to a selectable child.
             nk_console* new_active_child = nk_console_row_active_child(active);
-            if (new_active_child != NULL && !(new_active_child->flags & NK_CONSOLE_FLAG_SELECTABLE)) {
+            if (new_active_child != NULL && NK_FLAG_DISABLED(new_active_child->flags, NK_CONSOLE_FLAG_SELECTABLE)) {
                 nk_console_row_pick_nearest_selectable_child(active);
             }
         }
     }
 
     // Set the active widget to the active child of the row.
-    if (!(console->flags & NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && numChildren > 0) {
+    if (NK_FLAG_DISABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) && nk_console_is_active_widget(console) && numChildren > 0) {
         console->activeWidget = nk_console_row_active_child(console);
     }
 
     // Render all the children
     for (int i = 0; i < numChildren; ++i) {
         nk_console* child = console->children[i];
-        if (child->render != NULL && (child->flags & NK_CONSOLE_FLAG_VISIBLE)) {
+        if (child->render != NULL && NK_FLAG_ENABLED(child->flags, NK_CONSOLE_FLAG_VISIBLE)) {
             // If the row is disabled, then temporarily disable the child when rendering.
-            if ((console->flags & NK_CONSOLE_FLAG_DISABLED)) {
-                nk_bool child_disabled = (child->flags & NK_CONSOLE_FLAG_DISABLED);
+            if NK_FLAG_ENABLED(console->flags, NK_CONSOLE_FLAG_DISABLED) {
+                nk_bool child_disabled = NK_FLAG_ENABLED(child->flags, NK_CONSOLE_FLAG_DISABLED);
                 child->flags |= NK_CONSOLE_FLAG_DISABLED;
                 child->render(child);
                 if (!child_disabled) child->flags &= ~(nk_uint)NK_CONSOLE_FLAG_DISABLED;

--- a/nuklear_console_rule_horizontal.h
+++ b/nuklear_console_rule_horizontal.h
@@ -65,7 +65,7 @@ NK_API nk_console* nk_console_rule_horizontal(nk_console* parent, struct nk_colo
     rule->data = (void*)data;
     rule->render = nk_console_rule_horizontal_render;
     rule->flags |= NK_CONSOLE_FLAG_DISABLED;
-    rule->flags &= ~(nk_uint)NK_CONSOLE_FLAG_SELECTABLE;
+    rule->flags &= ~(nk_flags)NK_CONSOLE_FLAG_SELECTABLE;
     return rule;
 }
 

--- a/nuklear_console_rule_horizontal.h
+++ b/nuklear_console_rule_horizontal.h
@@ -64,8 +64,8 @@ NK_API nk_console* nk_console_rule_horizontal(nk_console* parent, struct nk_colo
     rule->alignment = NK_TEXT_CENTERED;
     rule->data = (void*)data;
     rule->render = nk_console_rule_horizontal_render;
-    rule->disabled = nk_true;
-    rule->selectable = nk_false;
+    rule->flags |= NK_CONSOLE_FLAG_DISABLED;
+    rule->flags &= ~(nk_uint)NK_CONSOLE_FLAG_SELECTABLE;
     return rule;
 }
 

--- a/nuklear_console_spacing.h
+++ b/nuklear_console_spacing.h
@@ -41,8 +41,8 @@ NK_API nk_console* nk_console_spacing(nk_console* parent, int cols) {
     spacing->type = NK_CONSOLE_SPACING;
     spacing->columns = cols;
     spacing->render = nk_console_spacing_render;
-    spacing->disabled = nk_true;
-    spacing->selectable = nk_false;
+    spacing->flags |= NK_CONSOLE_FLAG_DISABLED;
+    spacing->flags &= ~(nk_uint)NK_CONSOLE_FLAG_SELECTABLE;
     return spacing;
 }
 

--- a/nuklear_console_spacing.h
+++ b/nuklear_console_spacing.h
@@ -42,7 +42,7 @@ NK_API nk_console* nk_console_spacing(nk_console* parent, int cols) {
     spacing->columns = cols;
     spacing->render = nk_console_spacing_render;
     spacing->flags |= NK_CONSOLE_FLAG_DISABLED;
-    spacing->flags &= ~(nk_uint)NK_CONSOLE_FLAG_SELECTABLE;
+    spacing->flags &= ~(nk_flags)NK_CONSOLE_FLAG_SELECTABLE;
     return spacing;
 }
 

--- a/nuklear_console_textedit.h
+++ b/nuklear_console_textedit.h
@@ -324,7 +324,7 @@ NK_API nk_console* nk_console_textedit(nk_console* parent, const char* label, ch
     // Create the textedit widget.
     nk_console* textedit = nk_console_label(parent, label);
     textedit->type = NK_CONSOLE_TEXTEDIT;
-    textedit->selectable = nk_true;
+    textedit->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     data->buffer = buffer;
     data->buffer_size = buffer_size;
     textedit->columns = label != NULL ? 2 : 1;

--- a/nuklear_console_textedit_text.h
+++ b/nuklear_console_textedit_text.h
@@ -42,10 +42,10 @@ NK_API struct nk_rect nk_console_textedit_text_render(nk_console* widget) {
     nk_console_top_data* top_data = (nk_console_top_data*)nk_console_get_top(widget)->data;
 
     // Process checking the up/down switching in widgets before processing showing the widget itself
-    if (nk_console_is_active_widget(widget) && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (nk_console_is_active_widget(widget) && NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Allow using ENTER to go back
         if (nk_console_button_pushed(widget, NK_GAMEPAD_BUTTON_A)) {
-            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+            top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             nk_console_textedit_button_back_click(widget, NULL);
             return nk_rect(0, 0, 0, 0);
         }

--- a/nuklear_console_textedit_text.h
+++ b/nuklear_console_textedit_text.h
@@ -42,10 +42,10 @@ NK_API struct nk_rect nk_console_textedit_text_render(nk_console* widget) {
     nk_console_top_data* top_data = (nk_console_top_data*)nk_console_get_top(widget)->data;
 
     // Process checking the up/down switching in widgets before processing showing the widget itself
-    if (nk_console_is_active_widget(widget) && top_data->input_processed == nk_false) {
+    if (nk_console_is_active_widget(widget) && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Allow using ENTER to go back
         if (nk_console_button_pushed(widget, NK_GAMEPAD_BUTTON_A)) {
-            top_data->input_processed = nk_true;
+            top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             nk_console_textedit_button_back_click(widget, NULL);
             return nk_rect(0, 0, 0, 0);
         }
@@ -58,7 +58,7 @@ NK_API struct nk_rect nk_console_textedit_text_render(nk_console* widget) {
         nk_console_check_tooltip(textedit);
     }
 
-    if (widget->disabled) {
+    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_begin(widget->ctx);
     }
 
@@ -108,7 +108,7 @@ NK_API struct nk_rect nk_console_textedit_text_render(nk_console* widget) {
         }
     }
 
-    if (widget->disabled) {
+    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
         nk_widget_disable_end(widget->ctx);
     }
 
@@ -121,7 +121,7 @@ NK_API nk_console* nk_console_textedit_text(nk_console* parent) {
     textedit_text->parent = parent;
     textedit_text->alignment = NK_TEXT_LEFT;
     textedit_text->columns = 1;
-    textedit_text->selectable = nk_true;
+    textedit_text->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     textedit_text->render = nk_console_textedit_text_render;
     return textedit_text;
 }

--- a/nuklear_console_textedit_text.h
+++ b/nuklear_console_textedit_text.h
@@ -42,7 +42,7 @@ NK_API struct nk_rect nk_console_textedit_text_render(nk_console* widget) {
     nk_console_top_data* top_data = (nk_console_top_data*)nk_console_get_top(widget)->data;
 
     // Process checking the up/down switching in widgets before processing showing the widget itself
-    if (nk_console_is_active_widget(widget) && !(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+    if (nk_console_is_active_widget(widget) && NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
         // Allow using ENTER to go back
         if (nk_console_button_pushed(widget, NK_GAMEPAD_BUTTON_A)) {
             top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
@@ -58,7 +58,7 @@ NK_API struct nk_rect nk_console_textedit_text_render(nk_console* widget) {
         nk_console_check_tooltip(textedit);
     }
 
-    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_begin(widget->ctx);
     }
 
@@ -108,7 +108,7 @@ NK_API struct nk_rect nk_console_textedit_text_render(nk_console* widget) {
         }
     }
 
-    if ((widget->flags & NK_CONSOLE_FLAG_DISABLED)) {
+    if NK_FLAG_ENABLED(widget->flags, NK_CONSOLE_FLAG_DISABLED) {
         nk_widget_disable_end(widget->ctx);
     }
 

--- a/nuklear_console_tree.h
+++ b/nuklear_console_tree.h
@@ -122,7 +122,7 @@ static struct nk_rect nk_console_tree_render(nk_console* tree) {
     if (nk_console_is_active_widget(tree)) {
         nk_console* top = nk_console_get_top(tree);
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+        if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT) && !nk_console_tree_expanded(tree)) {
                 nk_console_tree_apply_expanded(tree, nk_true);
                 nk_console_trigger_event(tree, NK_CONSOLE_EVENT_CHANGED);

--- a/nuklear_console_tree.h
+++ b/nuklear_console_tree.h
@@ -74,7 +74,8 @@ static void nk_console_tree_apply_expanded(nk_console* tree, nk_bool expanded) {
     nk_console** referenced_children = data->referenced_children;
     for (size_t i = 0; i < cvector_size(referenced_children); i++) {
         if (referenced_children[i] != NULL) {
-            referenced_children[i]->visible = expanded;
+            if (expanded) referenced_children[i]->flags |= NK_CONSOLE_FLAG_VISIBLE;
+            else referenced_children[i]->flags &= ~(nk_uint)NK_CONSOLE_FLAG_VISIBLE;
         }
     }
 
@@ -83,7 +84,7 @@ static void nk_console_tree_apply_expanded(nk_console* tree, nk_bool expanded) {
     if (top != NULL && top->data != NULL) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
         top_data->scroll_to_widget = tree;
-        top_data->scrollbar_required = nk_true;
+        top_data->state |= NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
     }
 }
 
@@ -121,15 +122,15 @@ static struct nk_rect nk_console_tree_render(nk_console* tree) {
     if (nk_console_is_active_widget(tree)) {
         nk_console* top = nk_console_get_top(tree);
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (!top_data->input_processed) {
+        if (!(top_data->state & NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT) && !nk_console_tree_expanded(tree)) {
                 nk_console_tree_apply_expanded(tree, nk_true);
                 nk_console_trigger_event(tree, NK_CONSOLE_EVENT_CHANGED);
-                top_data->input_processed = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             } else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT) && nk_console_tree_expanded(tree)) {
                 nk_console_tree_apply_expanded(tree, nk_false);
                 nk_console_trigger_event(tree, NK_CONSOLE_EVENT_CHANGED);
-                top_data->input_processed = nk_true;
+                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
         }
     }
@@ -187,7 +188,7 @@ NK_API nk_console* nk_console_tree(nk_console* parent, const char* label, nk_boo
     }
     widget->type = NK_CONSOLE_TREE;
     widget->data = (void*)data;
-    widget->selectable = nk_true;
+    widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
     widget->columns = 1;
     widget->render = nk_console_tree_render;
     data->button.symbol = expanded ? NK_SYMBOL_TRIANGLE_DOWN : NK_SYMBOL_TRIANGLE_RIGHT;

--- a/nuklear_console_tree.h
+++ b/nuklear_console_tree.h
@@ -75,7 +75,7 @@ static void nk_console_tree_apply_expanded(nk_console* tree, nk_bool expanded) {
     for (size_t i = 0; i < cvector_size(referenced_children); i++) {
         if (referenced_children[i] != NULL) {
             if (expanded) referenced_children[i]->flags |= NK_CONSOLE_FLAG_VISIBLE;
-            else referenced_children[i]->flags &= ~(nk_uint)NK_CONSOLE_FLAG_VISIBLE;
+            else referenced_children[i]->flags &= ~(nk_flags)NK_CONSOLE_FLAG_VISIBLE;
         }
     }
 

--- a/nuklear_console_tree.h
+++ b/nuklear_console_tree.h
@@ -84,7 +84,7 @@ static void nk_console_tree_apply_expanded(nk_console* tree, nk_bool expanded) {
     if (top != NULL && top->data != NULL) {
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
         top_data->scroll_to_widget = tree;
-        top_data->state |= NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
+        top_data->flags |= NK_CONSOLE_TOP_FLAG_SCROLLBAR_REQUIRED;
     }
 }
 
@@ -122,15 +122,15 @@ static struct nk_rect nk_console_tree_render(nk_console* tree) {
     if (nk_console_is_active_widget(tree)) {
         nk_console* top = nk_console_get_top(tree);
         nk_console_top_data* top_data = (nk_console_top_data*)top->data;
-        if (NK_FLAG_DISABLED(top_data->state, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
+        if (NK_FLAG_DISABLED(top_data->flags, NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED)) {
             if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_RIGHT) && !nk_console_tree_expanded(tree)) {
                 nk_console_tree_apply_expanded(tree, nk_true);
                 nk_console_trigger_event(tree, NK_CONSOLE_EVENT_CHANGED);
-                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             } else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT) && nk_console_tree_expanded(tree)) {
                 nk_console_tree_apply_expanded(tree, nk_false);
                 nk_console_trigger_event(tree, NK_CONSOLE_EVENT_CHANGED);
-                top_data->state |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
+                top_data->flags |= NK_CONSOLE_TOP_FLAG_INPUT_PROCESSED;
             }
         }
     }

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -447,16 +447,16 @@ int main() {
     // nk_console_selectable()
     {
         nk_console* widget = nk_console_label(console, "Selectable");
-        widget->flags &= ~(nk_flags)NK_CONSOLE_FLAG_SELECTABLE;
-        widget->flags &= ~(nk_flags)NK_CONSOLE_FLAG_DISABLED;
+        NK_FLAG_CLEAR(widget->flags, NK_CONSOLE_FLAG_SELECTABLE);
+        NK_FLAG_CLEAR(widget->flags, NK_CONSOLE_FLAG_DISABLED);
         assert(nk_console_selectable(widget) == nk_false);
         widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
         assert(nk_console_selectable(widget) == nk_true);
         widget->flags |= NK_CONSOLE_FLAG_DISABLED;
         assert(nk_console_selectable(widget) == nk_false);
         widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
-        widget->flags &= ~(nk_flags)NK_CONSOLE_FLAG_DISABLED;
-        widget->flags |= NK_CONSOLE_FLAG_VISIBLE;
+        NK_FLAG_CLEAR(widget->flags, NK_CONSOLE_FLAG_DISABLED);
+        NK_FLAG_SET(widget->flags, NK_CONSOLE_FLAG_VISIBLE);
         assert(nk_console_selectable(widget) == nk_true);
         widget->flags &= ~(nk_flags)NK_CONSOLE_FLAG_VISIBLE;
         assert(nk_console_selectable(widget) == nk_false);

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -393,19 +393,53 @@ int main() {
     // nk_console_selectable()
     {
         nk_console* widget = nk_console_label(console, "Selectable");
-        widget->flags &= ~(nk_uint)NK_CONSOLE_FLAG_SELECTABLE;
-        widget->flags &= ~(nk_uint)NK_CONSOLE_FLAG_DISABLED;
+        widget->flags &= ~(nk_flags)NK_CONSOLE_FLAG_SELECTABLE;
+        widget->flags &= ~(nk_flags)NK_CONSOLE_FLAG_DISABLED;
         assert(nk_console_selectable(widget) == nk_false);
         widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
         assert(nk_console_selectable(widget) == nk_true);
         widget->flags |= NK_CONSOLE_FLAG_DISABLED;
         assert(nk_console_selectable(widget) == nk_false);
         widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
-        widget->flags &= ~(nk_uint)NK_CONSOLE_FLAG_DISABLED;
+        widget->flags &= ~(nk_flags)NK_CONSOLE_FLAG_DISABLED;
         widget->flags |= NK_CONSOLE_FLAG_VISIBLE;
         assert(nk_console_selectable(widget) == nk_true);
-        widget->flags &= ~(nk_uint)NK_CONSOLE_FLAG_VISIBLE;
+        widget->flags &= ~(nk_flags)NK_CONSOLE_FLAG_VISIBLE;
         assert(nk_console_selectable(widget) == nk_false);
+    }
+
+    // nk_console_set_selectable/disabled/visible() + getters
+    {
+        nk_console* widget = nk_console_label(console, "Flag Accessors");
+
+        nk_console_set_selectable(widget, nk_true);
+        assert(nk_console_get_selectable(widget) == nk_true);
+        nk_console_set_selectable(widget, nk_false);
+        assert(nk_console_get_selectable(widget) == nk_false);
+
+        nk_console_set_disabled(widget, nk_true);
+        assert(nk_console_get_disabled(widget) == nk_true);
+        nk_console_set_disabled(widget, nk_false);
+        assert(nk_console_get_disabled(widget) == nk_false);
+
+        nk_console_set_visible(widget, nk_true);
+        assert(nk_console_get_visible(widget) == nk_true);
+        nk_console_set_visible(widget, nk_false);
+        assert(nk_console_get_visible(widget) == nk_false);
+
+        // The setters compose with the focusable check in nk_console_selectable().
+        nk_console_set_selectable(widget, nk_true);
+        nk_console_set_visible(widget, nk_true);
+        nk_console_set_disabled(widget, nk_false);
+        assert(nk_console_selectable(widget) == nk_true);
+        nk_console_set_disabled(widget, nk_true);
+        assert(nk_console_selectable(widget) == nk_false);
+
+        // NULL safety.
+        nk_console_set_selectable(NULL, nk_true);
+        assert(nk_console_get_selectable(NULL) == nk_false);
+        assert(nk_console_get_disabled(NULL) == nk_false);
+        assert(nk_console_get_visible(NULL) == nk_false);
     }
 
     // nk_console_knob_int/float()

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -393,18 +393,18 @@ int main() {
     // nk_console_selectable()
     {
         nk_console* widget = nk_console_label(console, "Selectable");
-        widget->selectable = nk_false;
-        widget->disabled = nk_false;
+        widget->flags &= ~(nk_uint)NK_CONSOLE_FLAG_SELECTABLE;
+        widget->flags &= ~(nk_uint)NK_CONSOLE_FLAG_DISABLED;
         assert(nk_console_selectable(widget) == nk_false);
-        widget->selectable = nk_true;
+        widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
         assert(nk_console_selectable(widget) == nk_true);
-        widget->disabled = nk_true;
+        widget->flags |= NK_CONSOLE_FLAG_DISABLED;
         assert(nk_console_selectable(widget) == nk_false);
-        widget->selectable = nk_true;
-        widget->disabled = nk_false;
-        widget->visible = nk_true;
+        widget->flags |= NK_CONSOLE_FLAG_SELECTABLE;
+        widget->flags &= ~(nk_uint)NK_CONSOLE_FLAG_DISABLED;
+        widget->flags |= NK_CONSOLE_FLAG_VISIBLE;
         assert(nk_console_selectable(widget) == nk_true);
-        widget->visible = nk_false;
+        widget->flags &= ~(nk_uint)NK_CONSOLE_FLAG_VISIBLE;
         assert(nk_console_selectable(widget) == nk_false);
     }
 


### PR DESCRIPTION
Replace individual `nk_bool selectable/disabled/visible` fields in `nk_console` and the per-frame booleans in `nk_console_top_data` with single `nk_uint flags`/`state` fields backed by `nk_console_flag` and `nk_console_top_flag` enums, reducing memory use per widget instance.

Fixes #97