### PR TITLE
fix: configurable message max length with assert

### DIFF
--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -80,8 +80,16 @@ typedef enum {
     NK_CONSOLE_LIST_VIEW,
 } nk_console_widget_type;
 
+#ifndef NK_CONSOLE_MESSAGE_MAX_LENGTH
+/**
+ * Maximum number of characters (excluding null terminator) for a message.
+ * Define before including nuklear_console.h to allow longer messages.
+ */
+#define NK_CONSOLE_MESSAGE_MAX_LENGTH 255
+#endif // NK_CONSOLE_MESSAGE_MAX_LENGTH
+
 typedef struct nk_console_message {
-    char text[256];
+    char text[NK_CONSOLE_MESSAGE_MAX_LENGTH + 1];
     float duration;
     float scroll_x;
 } nk_console_message;

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -89,10 +89,11 @@ NK_API void nk_console_show_message(nk_console* console, const char* text) {
         return;
     }
 
-    // Grab the length of the string, limit length to 255.
+    // Grab the length of the string, clamped to NK_CONSOLE_MESSAGE_MAX_LENGTH.
     int len = nk_strlen(text);
-    if (len > 255) {
-        len = 255;
+    NK_ASSERT(len <= NK_CONSOLE_MESSAGE_MAX_LENGTH);
+    if (len > NK_CONSOLE_MESSAGE_MAX_LENGTH) {
+        len = NK_CONSOLE_MESSAGE_MAX_LENGTH;
     }
 
     // Only add the message if it's not already in the queue.
@@ -114,7 +115,7 @@ NK_API void nk_console_show_message(nk_console* console, const char* text) {
     nk_console_message message = {0};
     message.duration = NK_CONSOLE_MESSAGE_DURATION;
     NK_MEMCPY(message.text, text, (nk_size)len);
-    message.text[len] = '\0'; // Make sure it's null-terminated
+    message.text[len] = '\0';
 
     // Add the new message to the message queue.
     cvector_push_back(data->messages, message);


### PR DESCRIPTION
Closes #239

Introduces `NK_CONSOLE_MESSAGE_MAX_LENGTH` (default 255, backwards-compatible) so callers can define a larger limit before including the header. Adds `NK_ASSERT` to surface truncation in debug builds rather than silently dropping characters.

## Test plan
- Default behavior unchanged — existing tests pass.
- Define `NK_CONSOLE_MESSAGE_MAX_LENGTH 511` before including; confirm a 400-character message is stored and displayed in full.