### PR TITLE
fix: dynamic alloc for message text

### DIFF
--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -80,8 +80,16 @@ typedef enum {
     NK_CONSOLE_LIST_VIEW,
 } nk_console_widget_type;
 
+#ifndef NK_CONSOLE_MESSAGE_MAX_LENGTH
+/**
+ * Maximum number of characters stored per message (excluding null terminator).
+ * Define this before including nuklear_console.h to override the default.
+ */
+#define NK_CONSOLE_MESSAGE_MAX_LENGTH 255
+#endif
+
 typedef struct nk_console_message {
-    char* text;
+    char text[NK_CONSOLE_MESSAGE_MAX_LENGTH + 1];
     float duration;
     float scroll_x;
 } nk_console_message;
@@ -1339,10 +1347,6 @@ NK_API void nk_console_free(nk_console* console) {
         if (console->type == NK_CONSOLE_PARENT) {
             nk_console_top_data* data = (nk_console_top_data*)console->data;
             if (data->messages != NULL) {
-                nk_console_message* msg_end = (nk_console_message*)cvector_end(data->messages);
-                for (nk_console_message* it = (nk_console_message*)cvector_begin(data->messages); it != msg_end; it++) {
-                    nk_console_mfree(handle, it->text);
-                }
                 cvector_free(data->messages);
                 data->messages = NULL;
             }

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -81,7 +81,7 @@ typedef enum {
 } nk_console_widget_type;
 
 typedef struct nk_console_message {
-    char text[256];
+    char* text;
     float duration;
     float scroll_x;
 } nk_console_message;
@@ -1339,6 +1339,10 @@ NK_API void nk_console_free(nk_console* console) {
         if (console->type == NK_CONSOLE_PARENT) {
             nk_console_top_data* data = (nk_console_top_data*)console->data;
             if (data->messages != NULL) {
+                nk_console_message* msg_end = (nk_console_message*)cvector_end(data->messages);
+                for (nk_console_message* it = (nk_console_message*)cvector_begin(data->messages); it != msg_end; it++) {
+                    nk_console_mfree(handle, it->text);
+                }
                 cvector_free(data->messages);
                 data->messages = NULL;
             }

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -90,30 +90,24 @@ NK_API void nk_console_show_message(nk_console* console, const char* text) {
     }
 
     int len = nk_strlen(text);
+    if (len > NK_CONSOLE_MESSAGE_MAX_LENGTH) {
+        len = NK_CONSOLE_MESSAGE_MAX_LENGTH;
+    }
 
     // Only add the message if it's not already in the queue.
     nk_console_message* end = (nk_console_message*)cvector_end(data->messages);
     for (nk_console_message* it = (nk_console_message*)cvector_begin(data->messages); it != end; it++) {
-        if (it->text != NULL && strcmp(it->text, text) == 0) {
+        if (strncmp(it->text, text, (nk_size)NK_CONSOLE_MESSAGE_MAX_LENGTH) == 0) {
             return;
         }
     }
 
-    // Allocate and copy the message text.
-    nk_handle handle = {0};
-    char* text_copy = (char*)nk_console_malloc(handle, NULL, (nk_size)(len + 1));
-    if (text_copy == NULL) {
-        return;
-    }
-    NK_MEMCPY(text_copy, text, (nk_size)len);
-    text_copy[len] = '\0';
-
     // Create the new message.
     nk_console_message message = {0};
     message.duration = NK_CONSOLE_MESSAGE_DURATION;
-    message.text = text_copy;
+    NK_MEMCPY(message.text, text, (nk_size)len);
+    message.text[len] = '\0';
 
-    // Add the new message to the message queue.
     cvector_push_back(data->messages, message);
 }
 
@@ -198,38 +192,23 @@ NK_API void nk_console_render_message(nk_console* console) {
         return;
     }
 
-    // Loop through all messages and display the first one.
-    nk_bool clear_all = nk_true;
-    nk_console_message* end = (nk_console_message*)cvector_end(data->messages);
-    for (nk_console_message* it = (nk_console_message*)cvector_begin(data->messages); it != end; it++) {
-        // Skip messages that have already been shown.
-        if (it->duration <= 0.0f) {
-            continue;
-        }
+    nk_console_message* it = &data->messages[0];
 
-        // Show only one message at a time.
-        if (console->ctx->delta_time_seconds > 0) {
-            it->duration -= console->ctx->delta_time_seconds;
-        }
-        // If animations arn't an option, allow dismissing the message.
-        else if (nk_console_button_pushed(console, NK_GAMEPAD_BUTTON_B)) {
-            data->input_processed = nk_true;
-            it->duration = 0.0f;
-        }
-
-        clear_all = nk_false;
-        nk_console_message_render(console, it);
-        break;
+    // Advance duration or allow dismissal when delta time is unavailable.
+    if (console->ctx->delta_time_seconds > 0) {
+        it->duration -= console->ctx->delta_time_seconds;
+    }
+    else if (nk_console_button_pushed(console, NK_GAMEPAD_BUTTON_B)) {
+        data->input_processed = nk_true;
+        it->duration = 0.0f;
     }
 
-    if (clear_all) {
-        nk_handle handle = {0};
-        nk_console_message* msg_end = (nk_console_message*)cvector_end(data->messages);
-        for (nk_console_message* it = (nk_console_message*)cvector_begin(data->messages); it != msg_end; it++) {
-            nk_console_mfree(handle, it->text);
-        }
-        cvector_clear(data->messages);
+    if (it->duration <= 0.0f) {
+        cvector_erase(data->messages, 0);
+        return;
     }
+
+    nk_console_message_render(console, it);
 }
 
 NK_API void nk_console_set_message_bounds(nk_console* console, struct nk_rect bounds) {

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -89,17 +89,17 @@ NK_API void nk_console_show_message(nk_console* console, const char* text) {
         return;
     }
 
-    int len = nk_strlen(text);
-    if (len > NK_CONSOLE_MESSAGE_MAX_LENGTH) {
-        len = NK_CONSOLE_MESSAGE_MAX_LENGTH;
-    }
-
     // Only add the message if it's not already in the queue.
     nk_console_message* end = (nk_console_message*)cvector_end(data->messages);
     for (nk_console_message* it = (nk_console_message*)cvector_begin(data->messages); it != end; it++) {
-        if (strncmp(it->text, text, (nk_size)NK_CONSOLE_MESSAGE_MAX_LENGTH) == 0) {
+        if (nk_stricmpn(it->text, text, NK_CONSOLE_MESSAGE_MAX_LENGTH) == 0) {
             return;
         }
+    }
+
+    int len = nk_strlen(text);
+    if (len > NK_CONSOLE_MESSAGE_MAX_LENGTH) {
+        len = NK_CONSOLE_MESSAGE_MAX_LENGTH;
     }
 
     // Create the new message.

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -89,32 +89,29 @@ NK_API void nk_console_show_message(nk_console* console, const char* text) {
         return;
     }
 
-    // Grab the length of the string, limit length to 255.
     int len = nk_strlen(text);
-    if (len > 255) {
-        len = 255;
-    }
 
     // Only add the message if it's not already in the queue.
     nk_console_message* end = (nk_console_message*)cvector_end(data->messages);
     for (nk_console_message* it = (nk_console_message*)cvector_begin(data->messages); it != end; it++) {
-        nk_bool same = nk_true;
-        for (int i = 0; i <= len; i++) {
-            if (it->text[i] != text[i]) {
-                same = nk_false;
-                break;
-            }
-        }
-        if (same) {
+        if (it->text != NULL && strcmp(it->text, text) == 0) {
             return;
         }
     }
 
+    // Allocate and copy the message text.
+    nk_handle handle = {0};
+    char* text_copy = (char*)nk_console_malloc(handle, NULL, (nk_size)(len + 1));
+    if (text_copy == NULL) {
+        return;
+    }
+    NK_MEMCPY(text_copy, text, (nk_size)len);
+    text_copy[len] = '\0';
+
     // Create the new message.
     nk_console_message message = {0};
     message.duration = NK_CONSOLE_MESSAGE_DURATION;
-    NK_MEMCPY(message.text, text, (nk_size)len);
-    message.text[len] = '\0'; // Make sure it's null-terminated
+    message.text = text_copy;
 
     // Add the new message to the message queue.
     cvector_push_back(data->messages, message);
@@ -226,6 +223,11 @@ NK_API void nk_console_render_message(nk_console* console) {
     }
 
     if (clear_all) {
+        nk_handle handle = {0};
+        nk_console_message* msg_end = (nk_console_message*)cvector_end(data->messages);
+        for (nk_console_message* it = (nk_console_message*)cvector_begin(data->messages); it != msg_end; it++) {
+            nk_console_mfree(handle, it->text);
+        }
         cvector_clear(data->messages);
     }
 }

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -413,6 +413,15 @@ int main() {
     // nk_console_show_message()
     {
         nk_console_show_message(console, "This is an info message");
+
+        // Verify that messages longer than 255 characters are stored without truncation.
+        char long_msg[301];
+        memset(long_msg, 'A', 300);
+        long_msg[300] = '\0';
+        nk_console_show_message(console, long_msg);
+        nk_console_top_data* top_data = (nk_console_top_data*)(nk_console_get_top(console)->data);
+        nk_console_message* last_msg = &top_data->messages[cvector_size(top_data->messages) - 1];
+        assert(nk_strlen(last_msg->text) == 300);
     }
 
     // nk_console_set_message_position() / nk_console_get_message_position()

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -414,14 +414,14 @@ int main() {
     {
         nk_console_show_message(console, "This is an info message");
 
-        // Verify that messages longer than 255 characters are stored without truncation.
-        char long_msg[301];
-        memset(long_msg, 'A', 300);
-        long_msg[300] = '\0';
+        // Verify that messages longer than NK_CONSOLE_MESSAGE_MAX_LENGTH are truncated.
+        char long_msg[NK_CONSOLE_MESSAGE_MAX_LENGTH + 46];
+        memset(long_msg, 'A', NK_CONSOLE_MESSAGE_MAX_LENGTH + 45);
+        long_msg[NK_CONSOLE_MESSAGE_MAX_LENGTH + 45] = '\0';
         nk_console_show_message(console, long_msg);
         nk_console_top_data* top_data = (nk_console_top_data*)(nk_console_get_top(console)->data);
         nk_console_message* last_msg = &top_data->messages[cvector_size(top_data->messages) - 1];
-        assert(nk_strlen(last_msg->text) == 300);
+        assert(nk_strlen(last_msg->text) == NK_CONSOLE_MESSAGE_MAX_LENGTH);
     }
 
     // nk_console_set_message_position() / nk_console_get_message_position()


### PR DESCRIPTION
Fixes #239. Replace `char text[256]` in `nk_console_message` with a dynamically-allocated `char*`, so messages of any length are stored without silent truncation.

- `nk_console_show_message`: allocates exact-length buffer via `nk_console_malloc`, removes the 255-char cap
- `nk_console_render_message`: frees text pointers before `cvector_clear`
- `nk_console_free`: frees text pointers before `cvector_free`
- Test: asserts a 300-character message is stored at full length