### PR TITLE
fix: NULL-checks after NK_CONSOLE_MALLOC in widget constructors

### DIFF
--- a/nuklear_console_button.h
+++ b/nuklear_console_button.h
@@ -193,6 +193,7 @@ NK_API struct nk_rect nk_console_button_render(nk_console* console) {
 NK_API nk_console* nk_console_button(nk_console* parent, const char* text) {
     // Create the widget data.
     nk_console_button_data* data = (nk_console_button_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_button_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_button_data));
 
     nk_console* button = nk_console_label(parent, text);

--- a/nuklear_console_checkbox.h
+++ b/nuklear_console_checkbox.h
@@ -118,6 +118,7 @@ NK_API struct nk_rect nk_console_checkbox_render(nk_console* console) {
 NK_API nk_console* nk_console_checkbox(nk_console* parent, const char* text, nk_bool* active) {
     NK_ASSERT(active != NULL);
     nk_console_checkbox_data* data = (nk_console_checkbox_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_checkbox_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_checkbox_data));
 
     nk_console* checkbox = nk_console_label(parent, text);

--- a/nuklear_console_color.h
+++ b/nuklear_console_color.h
@@ -114,6 +114,7 @@ NK_API nk_console* nk_console_color(nk_console* parent, const char* label, struc
 
     // Create the widget data.
     nk_console_color_data* data = (nk_console_color_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_color_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_color_data));
     data->color = color;
 

--- a/nuklear_console_combobox.h
+++ b/nuklear_console_combobox.h
@@ -158,6 +158,7 @@ NK_API void nk_console_combobox_update(nk_console* combobox, const char* label, 
 NK_API nk_console* nk_console_combobox(nk_console* parent, const char* label, const char* items_separated_by_separator, int separator, int* selected) {
     // Create the widget data.
     nk_console_combobox_data* data = (nk_console_combobox_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_combobox_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_combobox_data));
 
     // Set up the combobox

--- a/nuklear_console_file.h
+++ b/nuklear_console_file.h
@@ -1127,6 +1127,7 @@ NK_API nk_console* nk_console_file(nk_console* parent, const char* label, char* 
 
     // Create the widget data.
     nk_console_file_data* data = (nk_console_file_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_file_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_file_data));
 
     data->file_path_buffer = file_path_buffer;

--- a/nuklear_console_image.h
+++ b/nuklear_console_image.h
@@ -109,6 +109,7 @@ NK_API
 nk_console* nk_console_image_color(nk_console* parent, struct nk_image image, struct nk_color color) {
     nk_console_image_data* data =
         (nk_console_image_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(*data));
+    if (data == NULL) return NULL;
     data->image = image;
     data->color = color;
 

--- a/nuklear_console_input.h
+++ b/nuklear_console_input.h
@@ -711,6 +711,7 @@ NK_API nk_console* nk_console_input(nk_console* parent, const char* label, int g
     }
 
     data = (nk_console_input_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_input_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_input_data));
     data->gamepad_number = gamepad_number;
     data->out_gamepad_number = out_gamepad_number;

--- a/nuklear_console_knob.h
+++ b/nuklear_console_knob.h
@@ -43,6 +43,7 @@ extern "C" {
 NK_API nk_console* nk_console_knob_int(nk_console* parent, const char* label, int min, int* val, int max, int step, float inc_per_pixel) {
     // Create the property data.
     nk_console_knob_data* data = (nk_console_knob_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_knob_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_knob_data));
     data->property.min_int = min;
     data->property.val_int = val;

--- a/nuklear_console_progress.h
+++ b/nuklear_console_progress.h
@@ -37,6 +37,7 @@ NK_API nk_console* nk_console_progress(nk_console* parent, const char* text, nk_
 
     // Create the widget data.
     nk_console_progress_data* data = (nk_console_progress_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_progress_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_progress_data));
 
     nk_console* progress = nk_console_label(parent, text);

--- a/nuklear_console_property.h
+++ b/nuklear_console_property.h
@@ -251,6 +251,7 @@ NK_API struct nk_rect nk_console_property_render(nk_console* console) {
 NK_API nk_console* nk_console_property_int(nk_console* parent, const char* label, int min, int* val, int max, int step, float inc_per_pixel) {
     // Create the property data.
     nk_console_property_data* data = (nk_console_property_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_property_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_property_data));
     data->min_int = min;
     data->val_int = val;

--- a/nuklear_console_radio.h
+++ b/nuklear_console_radio.h
@@ -225,6 +225,7 @@ NK_API nk_console* nk_console_radio(nk_console* parent, const char* label, int* 
     }
 
     nk_console_radio_data* data = (nk_console_radio_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_radio_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_radio_data));
     data->selected = selected;
 

--- a/nuklear_console_row.h
+++ b/nuklear_console_row.h
@@ -107,6 +107,7 @@ static nk_bool nk_console_row_pick_nearest_selectable_child(nk_console* row) {
 NK_API nk_console* nk_console_row_begin(nk_console* parent) {
     // Create the row data.
     nk_console_row_data* data = (nk_console_row_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_row_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_row_data));
 
     // Create the row.

--- a/nuklear_console_rule_horizontal.h
+++ b/nuklear_console_rule_horizontal.h
@@ -56,6 +56,7 @@ NK_API nk_console* nk_console_rule_horizontal(nk_console* parent, struct nk_colo
     }
     nk_console_rule_horizontal_data* data =
         (nk_console_rule_horizontal_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_rule_horizontal_data));
+    if (data == NULL) return NULL;
     data->color = color;
     data->rounding = rounding;
 

--- a/nuklear_console_textedit.h
+++ b/nuklear_console_textedit.h
@@ -319,6 +319,7 @@ NK_API void nk_console_textedit_button_main_click(nk_console* button, void* user
 NK_API nk_console* nk_console_textedit(nk_console* parent, const char* label, char* buffer, int buffer_size) {
     // Create the widget data.
     nk_console_textedit_data* data = (nk_console_textedit_data*)NK_CONSOLE_MALLOC(nk_handle_id(0), NULL, sizeof(nk_console_textedit_data));
+    if (data == NULL) return NULL;
     nk_zero(data, sizeof(nk_console_textedit_data));
 
     // Create the textedit widget.


### PR DESCRIPTION
Add NULL-check after each NK_CONSOLE_MALLOC call in widget constructor functions to prevent NULL dereference on allocation failure. Fixes #244