### PR TITLE
docs: add NK_CONSOLE_GAMEPAD / NK_CONSOLE_NO_GAMEPAD to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ void nk_console_check_up_down(nk_console* widget);
 - `NK_CONSOLE_MESSAGE_SCROLL_SPEED`: Pixels per second at which a long message scrolls horizontally
 - `NK_CONSOLE_MESSAGE_SCROLL_PAUSE`: Seconds to pause at the start and end of a scrolling message
 - `NK_CONSOLE_FILE_SDL_NATIVE_DIALOG`: In SDL3, will enable file widgets to use native file dialogs
+- `NK_CONSOLE_GAMEPAD`: Defined automatically when [nuklear_gamepad](https://github.com/robloach/nuklear_gamepad) is included before nuklear_console; enables gamepad input support
+- `NK_CONSOLE_NO_GAMEPAD`: Define to force-disable gamepad support even when nuklear_gamepad is present; corresponds to CMake option `NUKLEAR_CONSOLE_GAMEPAD=OFF`
 
 ## Development
 


### PR DESCRIPTION
Document the gamepad configuration macros in the README config list, explaining auto-detection and how to force-disable gamepad support. Fixes #247