### PR TITLE
file: use forward slash as path separator everywhere

### DIFF
--- a/nuklear_console_file.h
+++ b/nuklear_console_file.h
@@ -513,7 +513,7 @@ NK_API void nk_console_file_normalize_path(char* buf, int size) {
 }
 
 /**
- * Appends a path component to data->directory, inserting the platform separator.
+ * Appends a path component to data->directory, inserting a forward-slash separator.
  * Returns nk_false and shows an error if the result would overflow the buffer.
  *
  * @internal
@@ -534,12 +534,7 @@ static nk_bool nk_console_file_append_to_directory(nk_console_file_data* data, n
         data->directory[0] = '\0';
     }
     else if (len > 0) {
-// TODO: file: Make sure this is cross-platform.
-#if defined(_WIN32) || defined(WIN32)
-        data->directory[len] = '\\';
-#else
         data->directory[len] = '/';
-#endif
         data->directory[len + 1] = '\0';
         len++;
     }

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -74,6 +74,11 @@ int main() {
         snprintf(path, sizeof(path), "a\\b\\..\\c");
         nk_console_file_normalize_path(path, sizeof(path));
         assert(strcmp(path, "a/c") == 0);
+
+        // Mixed separators are normalized to forward slash.
+        snprintf(path, sizeof(path), "a\\b/c\\d");
+        nk_console_file_normalize_path(path, sizeof(path));
+        assert(strcmp(path, "a/b/c/d") == 0);
     }
 
     // Load Nuklear


### PR DESCRIPTION
Replace the WIN32/non-WIN32 separator branch with a single forward slash, which nk_console_file_normalize_path already normalizes to. Adds a mixed-separator test. Fixes #246