### PR TITLE
file_system: add NUKLEAR_CONSOLE_ENABLE_TINYDIR cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,16 @@ project(nuklear_console
 )
 
 option(NUKLEAR_CONSOLE_GAMEPAD "Enable nuklear_gamepad gamepad input support" ON)
+option(NUKLEAR_CONSOLE_ENABLE_TINYDIR "Enable tinydir file-system backend" OFF)
 
 # nuklear_console
 add_library(nuklear_console INTERFACE)
 target_include_directories(nuklear_console INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+if (NUKLEAR_CONSOLE_ENABLE_TINYDIR)
+    target_compile_definitions(nuklear_console INTERFACE NK_CONSOLE_ENABLE_TINYDIR)
+    target_include_directories(nuklear_console INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/vendor/tinydir)
+endif()
 
 if (NUKLEAR_CONSOLE_GAMEPAD)
     find_package(nuklear_gamepad QUIET)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ void nk_console_check_up_down(nk_console* widget);
 - `NK_CONSOLE_IGNORE_BUTTON_TRIGGER_ON_RELEASE`: Define to suppress the `NK_BUTTON_TRIGGER_ON_RELEASE` warning
 - `NK_CONSOLE_FILE_PATH_MAX`: Maximum file path length used by the file widget
 - `NK_CONSOLE_FILE_ADD_FILES`: The function callback used to enumerate files; see `nk_console_file_add_files_tinydir()`
-- `NK_CONSOLE_ENABLE_TINYDIR`: Define to use tinydir for file enumeration
+- `NK_CONSOLE_ENABLE_TINYDIR`: Define to use tinydir for file enumeration; corresponds to CMake option `NUKLEAR_CONSOLE_ENABLE_TINYDIR=ON` (default: OFF)
 - `NK_CONSOLE_FILE_ADD_FILES_TINYDIR_H`: Path to the tinydir header when using the tinydir file backend
 - `NK_CONSOLE_FILE_ADD_FILES_TINYDIR_SKIP`: Define to skip the tinydir header include (provide your own include before)
 - `NK_CONSOLE_INPUT_TIMER`: Seconds to wait for input before timing out in the input widget

--- a/nuklear_console_file_system.h
+++ b/nuklear_console_file_system.h
@@ -32,7 +32,6 @@ extern "C" {
 extern "C" {
 #endif
 
-// TODO: Allow disabling tinydir
 #ifndef NK_CONSOLE_FILE_ADD_FILES
 #ifdef NK_CONSOLE_ENABLE_TINYDIR
 


### PR DESCRIPTION
Removes the resolved TODO comment and wires up a CMake option so tinydir is only pulled in when explicitly requested. Fixes #248