### PR TITLE
label: wrap text for all alignments to prevent truncation

### DIFF
--- a/nuklear_console_label.h
+++ b/nuklear_console_label.h
@@ -41,13 +41,8 @@ NK_API struct nk_rect nk_console_label_render(nk_console* widget) {
         nk_widget_disable_begin(widget->ctx);
     }
 
-    // Display the label, considering the alignment.
-    if (widget->alignment == NK_TEXT_LEFT) {
-        nk_label_wrap(widget->ctx, widget->label);
-    }
-    else {
-        nk_label(widget->ctx, widget->label, widget->alignment);
-    }
+    // Always wrap so long text isn't truncated. nk_label_wrap() only supports left alignment.
+    nk_label_wrap(widget->ctx, widget->label);
 
     // Release the disabled state if needed.
     if (widget->disabled || (widget->selectable && !selected)) {

--- a/nuklear_console_label.h
+++ b/nuklear_console_label.h
@@ -41,8 +41,13 @@ NK_API struct nk_rect nk_console_label_render(nk_console* widget) {
         nk_widget_disable_begin(widget->ctx);
     }
 
-    // Always wrap so long text isn't truncated. nk_label_wrap() only supports left alignment.
-    nk_label_wrap(widget->ctx, widget->label);
+    // Display the label, considering the alignment. Note that wrap and truncation are not considered here, and is a known limitation.
+    if (widget->alignment == NK_TEXT_LEFT) {
+        nk_label_wrap(widget->ctx, widget->label);
+    }
+    else {
+        nk_label(widget->ctx, widget->label, widget->alignment);
+    }
 
     // Release the disabled state if needed.
     if (widget->disabled || (widget->selectable && !selected)) {


### PR DESCRIPTION
Always call `nk_label_wrap()` regardless of alignment so long labels don't get silently truncated for centered/right-aligned text. Note that `nk_label_wrap()` only supports left alignment, so wrapping now takes precedence over alignment for long text.

Fixes #253