### PR TITLE
CI: enforce clang-format

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -12,6 +12,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  clang-format:
+    name: clang-format
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check formatting
+      run: |
+        clang-format --version
+        clang-format --dry-run --Werror *.h
+
   build:
     name: ${{ matrix.platform.os }} ${{ matrix.config.name }} ${{ matrix.type.name }}
     runs-on: ${{ matrix.platform.os }}

--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -499,20 +499,20 @@ static void* nk_console_cvector_realloc(void* old_ptr, nk_size new_size) {
     }
     return new_ptr;
 }
-#define cvector_clib_malloc(size)       nk_console_cvector_malloc(size)
-#define cvector_clib_free(ptr)          nk_console_cvector_free(ptr)
+#define cvector_clib_malloc(size) nk_console_cvector_malloc(size)
+#define cvector_clib_free(ptr) nk_console_cvector_free(ptr)
 #define cvector_clib_realloc(ptr, size) nk_console_cvector_realloc(ptr, size)
 #else
-    #ifndef cvector_clib_free
-    #define cvector_clib_free(ptr) nk_console_mfree(nk_handle_id(0), ptr)
-    #endif
-    #ifndef cvector_clib_malloc
-    #define cvector_clib_malloc(size) nk_console_malloc(nk_handle_id(0), NULL, size)
-    #endif
-    #ifndef cvector_clib_realloc
-    #include <stdlib.h>
-    #define cvector_clib_realloc(ptr, size) realloc(ptr, size)
-    #endif
+#ifndef cvector_clib_free
+#define cvector_clib_free(ptr) nk_console_mfree(nk_handle_id(0), ptr)
+#endif
+#ifndef cvector_clib_malloc
+#define cvector_clib_malloc(size) nk_console_malloc(nk_handle_id(0), NULL, size)
+#endif
+#ifndef cvector_clib_realloc
+#include <stdlib.h>
+#define cvector_clib_realloc(ptr, size) realloc(ptr, size)
+#endif
 #endif
 #ifndef cvector_clib_calloc
 #define cvector_clib_calloc(count, size) NK_ASSERT(0 && "cvector_clib_calloc is not supported")
@@ -539,8 +539,10 @@ static void* nk_console_cvector_memmove(void* dest, const void* src, nk_size cou
     if (d == s || count == 0) return dest;
     if (d < s) {
         while (count--) *d++ = *s++;
-    } else {
-        d += count; s += count;
+    }
+    else {
+        d += count;
+        s += count;
         while (count--) *--d = *--s;
     }
     return dest;
@@ -562,8 +564,8 @@ extern "C" {
 #include "nuklear_console_color.h"
 #include "nuklear_console_combobox.h"
 #include "nuklear_console_file.h"
-#include "nuklear_console_gamepad_stub.h"
 #include "nuklear_console_file_system.h"
+#include "nuklear_console_gamepad_stub.h"
 #include "nuklear_console_image.h"
 #include "nuklear_console_input.h"
 #include "nuklear_console_knob.h"
@@ -967,10 +969,7 @@ static void nk_console_tooltip_display(nk_console* console, const char* text) {
 
     int text_len = nk_strlen(text);
     float full_text_width = style->font->width(style->font->userdata, style->font->height, text, text_len);
-    nk_console_marquee_tooltip_render(ctx, text, text_len, full_text_width,
-        windowbounds.w - style->window.border, text_height,
-        NK_CONSOLE_TOOLTIP_SCROLL_SPEED, NK_CONSOLE_TOOLTIP_SCROLL_PAUSE,
-        &data->tooltip_scroll_x);
+    nk_console_marquee_tooltip_render(ctx, text, text_len, full_text_width, windowbounds.w - style->window.border, text_height, NK_CONSOLE_TOOLTIP_SCROLL_SPEED, NK_CONSOLE_TOOLTIP_SCROLL_PAUSE, &data->tooltip_scroll_x);
 
     ctx->input.mouse.pos.x = x;
     ctx->input.mouse.pos.y = y;
@@ -1136,7 +1135,7 @@ static void nk_console_process_post_render_events(nk_console* console) {
     if (count == 0) {
         return;
     }
-    for (size_t i = count; i-- > 0; ) {
+    for (size_t i = count; i-- > 0;) {
         if (console->events[i].type == NK_CONSOLE_EVENT_POST_RENDER_ONCE) {
             if (console->events[i].callback != NULL) {
                 console->events[i].callback((nk_console*)console->events[i].user_data, NULL);

--- a/nuklear_console_file.h
+++ b/nuklear_console_file.h
@@ -484,7 +484,8 @@ NK_API void nk_console_file_normalize_path(char* buf, int size) {
             if (seg_count > 0) {
                 seg_count--;
                 tmp_len = seg_ends[seg_count];
-            } else if (!absolute) {
+            }
+            else if (!absolute) {
                 int restore_len = tmp_len;
                 if (restore_len > 0 && tmp[restore_len - 1] != '/') {
                     if (tmp_len < size - 1) tmp[tmp_len++] = '/';
@@ -953,7 +954,10 @@ static SDL_DialogFileFilter* nk_console_file_build_sdl_filters(const char* filte
     int p = 0;
     const char* src = filter;
     while (*src) {
-        if (*src == '.') { src++; continue; }
+        if (*src == '.') {
+            src++;
+            continue;
+        }
         sdl_pattern[p++] = *src;
         src++;
     }
@@ -995,7 +999,8 @@ static void nk_console_file_event_clicked(nk_console* button, void* user_data) {
         const char* starting = data->starting_directory[0] ? data->starting_directory : NULL;
         if (data->select_directory) {
             SDL_ShowOpenFolderDialog(nk_console_file_sdl_dialog_callback, file, sdl_window, starting, false);
-        } else {
+        }
+        else {
             SDL_ShowOpenFileDialog(nk_console_file_sdl_dialog_callback, file, sdl_window, sdl_filters, filter_count, starting, false);
         }
         if (sdl_filters) NK_CONSOLE_FREE(nk_handle_id(0), sdl_filters);

--- a/nuklear_console_file_system.h
+++ b/nuklear_console_file_system.h
@@ -141,7 +141,8 @@ static SDL_EnumerationResult SDLCALL nk_console_file_add_files_sdl3_callback(voi
     size_t dirlen = SDL_strlen(dirname);
     if (dirlen > 0 && dirname[dirlen - 1] == '/') {
         SDL_snprintf(fullpath, sizeof(fullpath), "%s%s", dirname, fname);
-    } else {
+    }
+    else {
         SDL_snprintf(fullpath, sizeof(fullpath), "%s/%s", dirname, fname);
     }
 

--- a/nuklear_console_gamepad_stub.h
+++ b/nuklear_console_gamepad_stub.h
@@ -25,21 +25,33 @@ typedef struct nk_gamepads {
 } nk_gamepads;
 
 enum nk_gamepad_button {
-    NK_GAMEPAD_BUTTON_INVALID = -1, NK_GAMEPAD_BUTTON_FIRST = 0,
-    NK_GAMEPAD_BUTTON_UP = 0, NK_GAMEPAD_BUTTON_DOWN = 1,
-    NK_GAMEPAD_BUTTON_LEFT = 2, NK_GAMEPAD_BUTTON_RIGHT = 3,
-    NK_GAMEPAD_BUTTON_A = 4, NK_GAMEPAD_BUTTON_B = 5,
-    NK_GAMEPAD_BUTTON_X = 6, NK_GAMEPAD_BUTTON_Y = 7,
-    NK_GAMEPAD_BUTTON_LB = 8, NK_GAMEPAD_BUTTON_RB = 9,
-    NK_GAMEPAD_BUTTON_BACK = 10, NK_GAMEPAD_BUTTON_START = 11,
-    NK_GAMEPAD_BUTTON_GUIDE = 12, NK_GAMEPAD_BUTTON_LAST = 13
+    NK_GAMEPAD_BUTTON_INVALID = -1,
+    NK_GAMEPAD_BUTTON_FIRST = 0,
+    NK_GAMEPAD_BUTTON_UP = 0,
+    NK_GAMEPAD_BUTTON_DOWN = 1,
+    NK_GAMEPAD_BUTTON_LEFT = 2,
+    NK_GAMEPAD_BUTTON_RIGHT = 3,
+    NK_GAMEPAD_BUTTON_A = 4,
+    NK_GAMEPAD_BUTTON_B = 5,
+    NK_GAMEPAD_BUTTON_X = 6,
+    NK_GAMEPAD_BUTTON_Y = 7,
+    NK_GAMEPAD_BUTTON_LB = 8,
+    NK_GAMEPAD_BUTTON_RB = 9,
+    NK_GAMEPAD_BUTTON_BACK = 10,
+    NK_GAMEPAD_BUTTON_START = 11,
+    NK_GAMEPAD_BUTTON_GUIDE = 12,
+    NK_GAMEPAD_BUTTON_LAST = 13
 };
 
 enum nk_gamepad_axis {
-    NK_GAMEPAD_AXIS_INVALID = -1, NK_GAMEPAD_AXIS_FIRST = 0,
-    NK_GAMEPAD_AXIS_LEFT_X = 0, NK_GAMEPAD_AXIS_LEFT_Y = 1,
-    NK_GAMEPAD_AXIS_RIGHT_X = 2, NK_GAMEPAD_AXIS_RIGHT_Y = 3,
-    NK_GAMEPAD_AXIS_LEFT_TRIGGER = 4, NK_GAMEPAD_AXIS_RIGHT_TRIGGER = 5,
+    NK_GAMEPAD_AXIS_INVALID = -1,
+    NK_GAMEPAD_AXIS_FIRST = 0,
+    NK_GAMEPAD_AXIS_LEFT_X = 0,
+    NK_GAMEPAD_AXIS_LEFT_Y = 1,
+    NK_GAMEPAD_AXIS_RIGHT_X = 2,
+    NK_GAMEPAD_AXIS_RIGHT_Y = 3,
+    NK_GAMEPAD_AXIS_LEFT_TRIGGER = 4,
+    NK_GAMEPAD_AXIS_RIGHT_TRIGGER = 5,
     NK_GAMEPAD_AXIS_LAST = 6
 };
 
@@ -55,19 +67,31 @@ extern "C" {
 #endif
 
 static float nk_gamepad_get_axis(struct nk_gamepads* g, int n, enum nk_gamepad_axis a) {
-    NK_UNUSED(g); NK_UNUSED(n); NK_UNUSED(a); return 0.0f;
+    NK_UNUSED(g);
+    NK_UNUSED(n);
+    NK_UNUSED(a);
+    return 0.0f;
 }
 
 static nk_bool nk_gamepad_is_button_released(struct nk_gamepads* g, int n, enum nk_gamepad_button b) {
-    NK_UNUSED(g); NK_UNUSED(n); NK_UNUSED(b); return nk_false;
+    NK_UNUSED(g);
+    NK_UNUSED(n);
+    NK_UNUSED(b);
+    return nk_false;
 }
 
 static nk_bool nk_gamepad_is_button_down(struct nk_gamepads* g, int n, enum nk_gamepad_button b) {
-    NK_UNUSED(g); NK_UNUSED(n); NK_UNUSED(b); return nk_false;
+    NK_UNUSED(g);
+    NK_UNUSED(n);
+    NK_UNUSED(b);
+    return nk_false;
 }
 
 static nk_bool nk_gamepad_init(struct nk_gamepads* gamepads, struct nk_context* ctx, void* user_data) {
-    NK_UNUSED(gamepads); NK_UNUSED(ctx); NK_UNUSED(user_data); return nk_true;
+    NK_UNUSED(gamepads);
+    NK_UNUSED(ctx);
+    NK_UNUSED(user_data);
+    return nk_true;
 }
 
 static void nk_gamepad_free(struct nk_gamepads* gamepads) {

--- a/nuklear_console_input.h
+++ b/nuklear_console_input.h
@@ -13,55 +13,55 @@
  * @see nk_console_input_key()
  */
 
-#define NK_CONSOLE_KEY_NONE        0u /* Nothing */
-#define NK_CONSOLE_KEY_BACKSPACE   8u /* ASCII BS  */
-#define NK_CONSOLE_KEY_TAB         9u /* ASCII HT  */
-#define NK_CONSOLE_KEY_ENTER       13u /* ASCII CR  */
-#define NK_CONSOLE_KEY_ESCAPE      27u /* ASCII ESC */
-#define NK_CONSOLE_KEY_SPACE       32u /* ASCII SP  */
-#define NK_CONSOLE_KEY_DELETE      127u /* ASCII DEL */
+#define NK_CONSOLE_KEY_NONE 0u /* Nothing */
+#define NK_CONSOLE_KEY_BACKSPACE 8u /* ASCII BS  */
+#define NK_CONSOLE_KEY_TAB 9u /* ASCII HT  */
+#define NK_CONSOLE_KEY_ENTER 13u /* ASCII CR  */
+#define NK_CONSOLE_KEY_ESCAPE 27u /* ASCII ESC */
+#define NK_CONSOLE_KEY_SPACE 32u /* ASCII SP  */
+#define NK_CONSOLE_KEY_DELETE 127u /* ASCII DEL */
 
 /* Printable characters occupy 32 .. 0x10FFFF (stored as their codepoint). */
 
 /* Keys with no ASCII equivalent live one past Unicode's last codepoint. */
-#define NK_CONSOLE_KEY_SPECIAL     0x110000u
-#define NK_CONSOLE_KEY_UP          (NK_CONSOLE_KEY_SPECIAL + NK_KEY_UP)
-#define NK_CONSOLE_KEY_DOWN        (NK_CONSOLE_KEY_SPECIAL + NK_KEY_DOWN)
-#define NK_CONSOLE_KEY_LEFT        (NK_CONSOLE_KEY_SPECIAL + NK_KEY_LEFT)
-#define NK_CONSOLE_KEY_RIGHT       (NK_CONSOLE_KEY_SPECIAL + NK_KEY_RIGHT)
-#define NK_CONSOLE_KEY_SHIFT       (NK_CONSOLE_KEY_SPECIAL + NK_KEY_SHIFT)
-#define NK_CONSOLE_KEY_CTRL        (NK_CONSOLE_KEY_SPECIAL + NK_KEY_CTRL)
-#define NK_CONSOLE_KEY_ALT         (NK_CONSOLE_KEY_SPECIAL + NK_KEY_ALT)
-#define NK_CONSOLE_KEY_COPY        (NK_CONSOLE_KEY_SPECIAL + NK_KEY_COPY)
-#define NK_CONSOLE_KEY_CUT         (NK_CONSOLE_KEY_SPECIAL + NK_KEY_CUT)
-#define NK_CONSOLE_KEY_PASTE       (NK_CONSOLE_KEY_SPECIAL + NK_KEY_PASTE)
-#define NK_CONSOLE_KEY_INSERT      (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_INSERT_MODE)
-#define NK_CONSOLE_KEY_REPLACE     (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_REPLACE_MODE)
-#define NK_CONSOLE_KEY_HOME        (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_LINE_START)
-#define NK_CONSOLE_KEY_END         (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_LINE_END)
-#define NK_CONSOLE_KEY_TEXT_START  (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_START)
-#define NK_CONSOLE_KEY_TEXT_END    (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_END)
-#define NK_CONSOLE_KEY_UNDO        (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_UNDO)
-#define NK_CONSOLE_KEY_REDO        (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_REDO)
-#define NK_CONSOLE_KEY_SELECT_ALL  (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_SELECT_ALL)
-#define NK_CONSOLE_KEY_WORD_LEFT   (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_WORD_LEFT)
-#define NK_CONSOLE_KEY_WORD_RIGHT  (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_WORD_RIGHT)
+#define NK_CONSOLE_KEY_SPECIAL 0x110000u
+#define NK_CONSOLE_KEY_UP (NK_CONSOLE_KEY_SPECIAL + NK_KEY_UP)
+#define NK_CONSOLE_KEY_DOWN (NK_CONSOLE_KEY_SPECIAL + NK_KEY_DOWN)
+#define NK_CONSOLE_KEY_LEFT (NK_CONSOLE_KEY_SPECIAL + NK_KEY_LEFT)
+#define NK_CONSOLE_KEY_RIGHT (NK_CONSOLE_KEY_SPECIAL + NK_KEY_RIGHT)
+#define NK_CONSOLE_KEY_SHIFT (NK_CONSOLE_KEY_SPECIAL + NK_KEY_SHIFT)
+#define NK_CONSOLE_KEY_CTRL (NK_CONSOLE_KEY_SPECIAL + NK_KEY_CTRL)
+#define NK_CONSOLE_KEY_ALT (NK_CONSOLE_KEY_SPECIAL + NK_KEY_ALT)
+#define NK_CONSOLE_KEY_COPY (NK_CONSOLE_KEY_SPECIAL + NK_KEY_COPY)
+#define NK_CONSOLE_KEY_CUT (NK_CONSOLE_KEY_SPECIAL + NK_KEY_CUT)
+#define NK_CONSOLE_KEY_PASTE (NK_CONSOLE_KEY_SPECIAL + NK_KEY_PASTE)
+#define NK_CONSOLE_KEY_INSERT (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_INSERT_MODE)
+#define NK_CONSOLE_KEY_REPLACE (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_REPLACE_MODE)
+#define NK_CONSOLE_KEY_HOME (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_LINE_START)
+#define NK_CONSOLE_KEY_END (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_LINE_END)
+#define NK_CONSOLE_KEY_TEXT_START (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_START)
+#define NK_CONSOLE_KEY_TEXT_END (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_END)
+#define NK_CONSOLE_KEY_UNDO (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_UNDO)
+#define NK_CONSOLE_KEY_REDO (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_REDO)
+#define NK_CONSOLE_KEY_SELECT_ALL (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_SELECT_ALL)
+#define NK_CONSOLE_KEY_WORD_LEFT (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_WORD_LEFT)
+#define NK_CONSOLE_KEY_WORD_RIGHT (NK_CONSOLE_KEY_SPECIAL + NK_KEY_TEXT_WORD_RIGHT)
 #define NK_CONSOLE_KEY_SCROLL_START (NK_CONSOLE_KEY_SPECIAL + NK_KEY_SCROLL_START)
-#define NK_CONSOLE_KEY_SCROLL_END  (NK_CONSOLE_KEY_SPECIAL + NK_KEY_SCROLL_END)
+#define NK_CONSOLE_KEY_SCROLL_END (NK_CONSOLE_KEY_SPECIAL + NK_KEY_SCROLL_END)
 #define NK_CONSOLE_KEY_SCROLL_DOWN (NK_CONSOLE_KEY_SPECIAL + NK_KEY_SCROLL_DOWN)
-#define NK_CONSOLE_KEY_SCROLL_UP   (NK_CONSOLE_KEY_SPECIAL + NK_KEY_SCROLL_UP)
-#define NK_CONSOLE_KEY_F1          (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F1)
-#define NK_CONSOLE_KEY_F2          (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F2)
-#define NK_CONSOLE_KEY_F3          (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F3)
-#define NK_CONSOLE_KEY_F4          (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F4)
-#define NK_CONSOLE_KEY_F5          (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F5)
-#define NK_CONSOLE_KEY_F6          (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F6)
-#define NK_CONSOLE_KEY_F7          (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F7)
-#define NK_CONSOLE_KEY_F8          (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F8)
-#define NK_CONSOLE_KEY_F9          (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F9)
-#define NK_CONSOLE_KEY_F10         (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F10)
-#define NK_CONSOLE_KEY_F11         (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F11)
-#define NK_CONSOLE_KEY_F12         (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F12)
+#define NK_CONSOLE_KEY_SCROLL_UP (NK_CONSOLE_KEY_SPECIAL + NK_KEY_SCROLL_UP)
+#define NK_CONSOLE_KEY_F1 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F1)
+#define NK_CONSOLE_KEY_F2 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F2)
+#define NK_CONSOLE_KEY_F3 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F3)
+#define NK_CONSOLE_KEY_F4 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F4)
+#define NK_CONSOLE_KEY_F5 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F5)
+#define NK_CONSOLE_KEY_F6 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F6)
+#define NK_CONSOLE_KEY_F7 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F7)
+#define NK_CONSOLE_KEY_F8 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F8)
+#define NK_CONSOLE_KEY_F9 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F9)
+#define NK_CONSOLE_KEY_F10 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F10)
+#define NK_CONSOLE_KEY_F11 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F11)
+#define NK_CONSOLE_KEY_F12 (NK_CONSOLE_KEY_SPECIAL + NK_KEY_F12)
 
 /**
  * Flags that control which input sources are accepted by an input widget.
@@ -70,8 +70,8 @@
  */
 typedef enum nk_console_input_flags {
     NK_CONSOLE_INPUT_FLAG_GAMEPAD = NK_FLAG(0), /** Accept a gamepad button. @see out_gamepad_button */
-    NK_CONSOLE_INPUT_FLAG_KEY     = NK_FLAG(1), /** Accept a keyboard key (typed character or special key). @see out_key */
-    NK_CONSOLE_INPUT_FLAG_MOUSE   = NK_FLAG(2), /** Accept a mouse button. @see out_mouse_button */
+    NK_CONSOLE_INPUT_FLAG_KEY = NK_FLAG(1), /** Accept a keyboard key (typed character or special key). @see out_key */
+    NK_CONSOLE_INPUT_FLAG_MOUSE = NK_FLAG(2), /** Accept a mouse button. @see out_mouse_button */
 } nk_console_input_flags;
 
 /**
@@ -237,13 +237,28 @@ extern "C" {
 static const char* nk_gamepad_button_name(struct nk_gamepads* g, enum nk_gamepad_button b) {
     (void)g;
     static const char* names[] = {
-        "Up","Down","Left","Right","A","B","X","Y","LB","RB","Back","Start","Guide"
-    };
+        "Up",
+        "Down",
+        "Left",
+        "Right",
+        "A",
+        "B",
+        "X",
+        "Y",
+        "LB",
+        "RB",
+        "Back",
+        "Start",
+        "Guide"};
     if (b >= 0 && b < NK_GAMEPAD_BUTTON_LAST) return names[(int)b];
     return NULL;
 }
 static nk_bool nk_gamepad_any_button_released(struct nk_gamepads* g, int n, int* on, enum nk_gamepad_button* ob) {
-    (void)g; (void)n; (void)on; (void)ob; return nk_false;
+    (void)g;
+    (void)n;
+    (void)on;
+    (void)ob;
+    return nk_false;
 }
 #endif /* !NK_CONSOLE_GAMEPAD */
 
@@ -304,16 +319,18 @@ NK_API struct nk_rect nk_console_input_render(nk_console* console) {
     nk_console_button_set_symbol(console, NK_SYMBOL_NONE);
     if (active == NK_CONSOLE_INPUT_FLAG_KEY) {
         display_label = nk_console_input_key_name(*data->out_key);
-    } else if (active == NK_CONSOLE_INPUT_FLAG_MOUSE) {
+    }
+    else if (active == NK_CONSOLE_INPUT_FLAG_MOUSE) {
         switch (*data->out_mouse_button) {
-            case NK_BUTTON_LEFT: display_label = "Left Mouse";   break;
+            case NK_BUTTON_LEFT: display_label = "Left Mouse"; break;
             case NK_BUTTON_MIDDLE: display_label = "Middle Mouse"; break;
-            case NK_BUTTON_RIGHT: display_label = "Right Mouse";  break;
+            case NK_BUTTON_RIGHT: display_label = "Right Mouse"; break;
             case NK_BUTTON_X1: display_label = "Mouse X1"; break;
             case NK_BUTTON_X2: display_label = "Mouse X2"; break;
             default: display_label = "Mouse Button"; break;
         }
-    } else if (active == NK_CONSOLE_INPUT_FLAG_GAMEPAD) {
+    }
+    else if (active == NK_CONSOLE_INPUT_FLAG_GAMEPAD) {
         // Display the mocked button symbol
         switch (*data->out_gamepad_button) {
             case NK_GAMEPAD_BUTTON_UP:
@@ -403,11 +420,13 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
             *data->out_gamepad_button = data->default_gamepad_button;
             if (data->out_key != NULL) *data->out_key = NK_CONSOLE_KEY_NONE;
             if (data->out_mouse_button != NULL) *data->out_mouse_button = -1;
-        } else if (source == NK_CONSOLE_INPUT_FLAG_KEY) {
+        }
+        else if (source == NK_CONSOLE_INPUT_FLAG_KEY) {
             *data->out_key = data->default_key;
             if (data->out_gamepad_button != NULL) *data->out_gamepad_button = NK_GAMEPAD_BUTTON_INVALID;
             if (data->out_mouse_button != NULL) *data->out_mouse_button = -1;
-        } else if (source == NK_CONSOLE_INPUT_FLAG_MOUSE) {
+        }
+        else if (source == NK_CONSOLE_INPUT_FLAG_MOUSE) {
             *data->out_mouse_button = data->default_mouse_button;
             if (data->out_gamepad_button != NULL) *data->out_gamepad_button = NK_GAMEPAD_BUTTON_INVALID;
             if (data->out_key != NULL) *data->out_key = NK_CONSOLE_KEY_NONE;
@@ -426,17 +445,17 @@ static struct nk_rect nk_console_input_active_render(nk_console* console) {
         nk_uint source_flags = 0;
         const char* prompt;
         if (data->out_gamepad_button != NULL) source_flags |= NK_CONSOLE_INPUT_FLAG_GAMEPAD;
-        if (data->out_key != NULL)            source_flags |= NK_CONSOLE_INPUT_FLAG_KEY;
-        if (data->out_mouse_button != NULL)   source_flags |= NK_CONSOLE_INPUT_FLAG_MOUSE;
+        if (data->out_key != NULL) source_flags |= NK_CONSOLE_INPUT_FLAG_KEY;
+        if (data->out_mouse_button != NULL) source_flags |= NK_CONSOLE_INPUT_FLAG_MOUSE;
         switch (source_flags) {
-            case NK_CONSOLE_INPUT_FLAG_GAMEPAD:                                          prompt = "Press a Button";                      break;
-            case NK_CONSOLE_INPUT_FLAG_KEY:                                              prompt = "Press a Key";                         break;
-            case NK_CONSOLE_INPUT_FLAG_MOUSE:                                            prompt = "Press a Mouse Button";                break;
-            case NK_CONSOLE_INPUT_FLAG_GAMEPAD | NK_CONSOLE_INPUT_FLAG_KEY:              prompt = "Press a Button or Key";               break;
-            case NK_CONSOLE_INPUT_FLAG_GAMEPAD | NK_CONSOLE_INPUT_FLAG_MOUSE:            prompt = "Press a Button or Mouse Button";      break;
-            case NK_CONSOLE_INPUT_FLAG_KEY     | NK_CONSOLE_INPUT_FLAG_MOUSE:            prompt = "Press a Key or Mouse Button";         break;
+            case NK_CONSOLE_INPUT_FLAG_GAMEPAD: prompt = "Press a Button"; break;
+            case NK_CONSOLE_INPUT_FLAG_KEY: prompt = "Press a Key"; break;
+            case NK_CONSOLE_INPUT_FLAG_MOUSE: prompt = "Press a Mouse Button"; break;
+            case NK_CONSOLE_INPUT_FLAG_GAMEPAD | NK_CONSOLE_INPUT_FLAG_KEY: prompt = "Press a Button or Key"; break;
+            case NK_CONSOLE_INPUT_FLAG_GAMEPAD | NK_CONSOLE_INPUT_FLAG_MOUSE: prompt = "Press a Button or Mouse Button"; break;
+            case NK_CONSOLE_INPUT_FLAG_KEY | NK_CONSOLE_INPUT_FLAG_MOUSE: prompt = "Press a Key or Mouse Button"; break;
             case NK_CONSOLE_INPUT_FLAG_GAMEPAD | NK_CONSOLE_INPUT_FLAG_KEY | NK_CONSOLE_INPUT_FLAG_MOUSE: prompt = "Press a Button, Key, or Mouse Button"; break;
-            default:                                                                     prompt = "Press a Button";                      break;
+            default: prompt = "Press a Button"; break;
         }
         nk_label(console->ctx, prompt, NK_TEXT_CENTERED);
     }

--- a/nuklear_console_list_view.h
+++ b/nuklear_console_list_view.h
@@ -142,7 +142,7 @@ static nk_bool nk_console_list_view_item_matches(const char* label, const char* 
         int j = 0;
         while (filter[j] != '\0' && label[i + j] != '\0' &&
                nk_console_list_view_tolower((unsigned char)label[i + j]) ==
-               nk_console_list_view_tolower((unsigned char)filter[j])) {
+                   nk_console_list_view_tolower((unsigned char)filter[j])) {
             j++;
         }
         if (filter[j] == '\0') return nk_true;
@@ -294,7 +294,7 @@ NK_API const char* nk_console_list_view_selected_label(nk_console* list_view) {
     // When a filter is active and the selected item doesn't pass it (i.e. there
     // are no matches), there is no meaningful visible selection.
     if (data->searchable && data->search_buffer[0] != '\0' &&
-            !nk_console_list_view_item_matches(label, data->search_buffer)) {
+        !nk_console_list_view_item_matches(label, data->search_buffer)) {
         return NULL;
     }
     return label;
@@ -362,10 +362,8 @@ NK_API struct nk_rect nk_console_list_view_render(nk_console* widget) {
     // When calculating the height, consider the header height too.
     float header_height = 0.0f;
     if ((data->flags & (NK_WINDOW_TITLE | NK_WINDOW_CLOSABLE | NK_WINDOW_MINIMIZABLE)) &&
-            !(data->flags & NK_WINDOW_HIDDEN) && widget->label != NULL) {
-        header_height = top->ctx->style.font->height
-            + 2.0f * top->ctx->style.window.header.padding.y
-            + 2.0f * top->ctx->style.window.header.label_padding.y;
+        !(data->flags & NK_WINDOW_HIDDEN) && widget->label != NULL) {
+        header_height = top->ctx->style.font->height + 2.0f * top->ctx->style.window.header.padding.y + 2.0f * top->ctx->style.window.header.label_padding.y;
     }
 
     // Determine how many rows to show and the overall box height.

--- a/nuklear_console_marquee.h
+++ b/nuklear_console_marquee.h
@@ -21,12 +21,15 @@
  */
 static const char* nk_console_marquee_slice(
     struct nk_context* ctx,
-    const char* text, int text_len,
-    float full_text_width, float avail_width,
-    float speed, float pause,
+    const char* text,
+    int text_len,
+    float full_text_width,
+    float avail_width,
+    float speed,
+    float pause,
     float* scroll_x,
-    char* buf, int buf_size)
-{
+    char* buf,
+    int buf_size) {
     if (full_text_width <= avail_width || ctx->delta_time_seconds <= 0) {
         return text;
     }
@@ -43,8 +46,13 @@ static const char* nk_console_marquee_slice(
     int start = 0;
     for (int i = 1; i <= text_len; i++) {
         float w = ctx->style.font->width(ctx->style.font->userdata, ctx->style.font->height, text, i);
-        if (w >= offset) { start = i - 1; break; }
-        if (i == text_len) { start = text_len; }
+        if (w >= offset) {
+            start = i - 1;
+            break;
+        }
+        if (i == text_len) {
+            start = text_len;
+        }
     }
     int copy_len = text_len - start;
     if (copy_len >= buf_size) {
@@ -60,16 +68,17 @@ static const char* nk_console_marquee_slice(
  */
 static void nk_console_marquee_tooltip_render(
     struct nk_context* ctx,
-    const char* text, int text_len,
+    const char* text,
+    int text_len,
     float full_text_width,
-    float tooltip_width, float text_height,
-    float speed, float pause,
-    float* scroll_x)
-{
+    float tooltip_width,
+    float text_height,
+    float speed,
+    float pause,
+    float* scroll_x) {
     float avail_width = tooltip_width - ctx->style.window.padding.x * 2.0f;
     char display_buf[256];
-    const char* display_text = nk_console_marquee_slice(ctx, text, text_len,
-        full_text_width, avail_width, speed, pause, scroll_x, display_buf, (int)sizeof(display_buf));
+    const char* display_text = nk_console_marquee_slice(ctx, text, text_len, full_text_width, avail_width, speed, pause, scroll_x, display_buf, (int)sizeof(display_buf));
     struct nk_vec2 zero;
     nk_zero_struct(zero);
     if (nk_tooltip_begin_offset(ctx, tooltip_width, NK_TOP_LEFT, zero)) {

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -177,10 +177,7 @@ NK_API void nk_console_message_render(nk_console* console, nk_console_message* m
     float tooltip_width = bounds.w - ctx->style.window.border;
     int text_len = nk_strlen(message->text);
     float full_text_width = ctx->style.font->width(ctx->style.font->userdata, ctx->style.font->height, message->text, text_len);
-    nk_console_marquee_tooltip_render(ctx, message->text, text_len, full_text_width,
-        tooltip_width, text_height,
-        NK_CONSOLE_MESSAGE_SCROLL_SPEED, NK_CONSOLE_MESSAGE_SCROLL_PAUSE,
-        &message->scroll_x);
+    nk_console_marquee_tooltip_render(ctx, message->text, text_len, full_text_width, tooltip_width, text_height, NK_CONSOLE_MESSAGE_SCROLL_SPEED, NK_CONSOLE_MESSAGE_SCROLL_PAUSE, &message->scroll_x);
 
     // Restore the mouse x/y positions.
     ctx->input.mouse.pos = mouse_pos;

--- a/nuklear_console_sdl.h
+++ b/nuklear_console_sdl.h
@@ -32,9 +32,7 @@ NK_API void nk_console_sdl_update_text_input(nk_console* console, SDL_Window* wi
     nk_console* top = nk_console_get_top(console);
     nk_console_top_data* top_data = (nk_console_top_data*)top->data;
     nk_console* active_parent = top_data->active_parent;
-    nk_console* active = (active_parent != NULL) ?
-            active_parent->activeWidget :
-            NULL;
+    nk_console* active = (active_parent != NULL) ? active_parent->activeWidget : NULL;
 
     // Text input must be active for SDL3 to deliver SDL_EVENT_TEXT_INPUT, which
     // is how printable characters reach Nuklear. Two console states need it:

--- a/nuklear_console_textedit.h
+++ b/nuklear_console_textedit.h
@@ -20,8 +20,8 @@
  * A row is a NULL-terminated array of these; the last entry has normal == NULL.
  */
 typedef struct nk_console_textedit_key {
-    const char* normal;   /**< Label when shift is off; NULL terminates a row. */
-    const char* shifted;  /**< Label when shift is on; NULL means same as normal. */
+    const char* normal; /**< Label when shift is off; NULL terminates a row. */
+    const char* shifted; /**< Label when shift is on; NULL means same as normal. */
 } nk_console_textedit_key;
 
 typedef struct nk_console_textedit_data {
@@ -87,32 +87,57 @@ extern "C" {
 
 /* Default ASCII keyboard layout rows (NULL-terminated; last row gets Shift+Backspace). */
 static const nk_console_textedit_key nk_console_textedit_ascii_row0[] = {
-    {"1","!"}, {"2","@"}, {"3","#"}, {"4","$"}, {"5","%"},
-    {"6","^"}, {"7","&"}, {"8","*"}, {"9","("}, {"0",")"},
-    {NULL, NULL}
-};
+    {"1", "!"},
+    {"2", "@"},
+    {"3", "#"},
+    {"4", "$"},
+    {"5", "%"},
+    {"6", "^"},
+    {"7", "&"},
+    {"8", "*"},
+    {"9", "("},
+    {"0", ")"},
+    {NULL, NULL}};
 static const nk_console_textedit_key nk_console_textedit_ascii_row1[] = {
-    {"q","Q"}, {"w","W"}, {"e","E"}, {"r","R"}, {"t","T"},
-    {"y","Y"}, {"u","U"}, {"i","I"}, {"o","O"}, {"p","P"},
-    {NULL, NULL}
-};
+    {"q", "Q"},
+    {"w", "W"},
+    {"e", "E"},
+    {"r", "R"},
+    {"t", "T"},
+    {"y", "Y"},
+    {"u", "U"},
+    {"i", "I"},
+    {"o", "O"},
+    {"p", "P"},
+    {NULL, NULL}};
 static const nk_console_textedit_key nk_console_textedit_ascii_row2[] = {
-    {"a","A"}, {"s","S"}, {"d","D"}, {"f","F"}, {"g","G"},
-    {"h","H"}, {"j","J"}, {"k","K"}, {"l","L"}, {".",">"},
-    {NULL, NULL}
-};
+    {"a", "A"},
+    {"s", "S"},
+    {"d", "D"},
+    {"f", "F"},
+    {"g", "G"},
+    {"h", "H"},
+    {"j", "J"},
+    {"k", "K"},
+    {"l", "L"},
+    {".", ">"},
+    {NULL, NULL}};
 static const nk_console_textedit_key nk_console_textedit_ascii_row3[] = {
-    {"z","Z"}, {"x","X"}, {"c","C"}, {"v","V"}, {"b","B"},
-    {"n","N"}, {"m","M"}, {",","<"},
-    {NULL, NULL}
-};
+    {"z", "Z"},
+    {"x", "X"},
+    {"c", "C"},
+    {"v", "V"},
+    {"b", "B"},
+    {"n", "N"},
+    {"m", "M"},
+    {",", "<"},
+    {NULL, NULL}};
 static const nk_console_textedit_key* nk_console_textedit_layout_ascii[] = {
     nk_console_textedit_ascii_row0,
     nk_console_textedit_ascii_row1,
     nk_console_textedit_ascii_row2,
     nk_console_textedit_ascii_row3,
-    NULL
-};
+    NULL};
 
 /**
  * Frees all the children for the given textedit as an event.

--- a/nuklear_console_tree.h
+++ b/nuklear_console_tree.h
@@ -126,7 +126,8 @@ static struct nk_rect nk_console_tree_render(nk_console* tree) {
                 nk_console_tree_apply_expanded(tree, nk_true);
                 nk_console_trigger_event(tree, NK_CONSOLE_EVENT_CHANGED);
                 top_data->input_processed = nk_true;
-            } else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT) && nk_console_tree_expanded(tree)) {
+            }
+            else if (nk_console_button_pushed(top, NK_GAMEPAD_BUTTON_LEFT) && nk_console_tree_expanded(tree)) {
                 nk_console_tree_apply_expanded(tree, nk_false);
                 nk_console_trigger_event(tree, NK_CONSOLE_EVENT_CHANGED);
                 top_data->input_processed = nk_true;


### PR DESCRIPTION
Add a clang-format check job to CI and fix existing formatting drift in root headers. Fixes #281