### PR TITLE
knob: expose zero_direction and dead_zone accessors

### DIFF
--- a/demo/common/nuklear_console_demo.c
+++ b/demo/common/nuklear_console_demo.c
@@ -443,7 +443,9 @@ struct nk_console* nuklear_console_demo_init(struct nk_context* ctx, void* user_
             nk_console_property_int(properties, "Property Int", 10, &property_int_test, 30, 1, 1);
             nk_console_property_float(properties, "Property Float", 0.0f, &property_float_test, 2.0f, 0.1f, 1);
             nk_console_knob_int(properties, "Knob Int", 0, &knob_int_test, 30, 1, 1);
-            nk_console_knob_float(properties, "Knob Float", 0.0f, &knob_float_test, 2.0f, 0.1f, 1);
+            nk_console* knob_float = nk_console_knob_float(properties, "Knob Float", 0.0f, &knob_float_test, 2.0f, 0.1f, 1);
+            nk_console_knob_set_zero_direction(knob_float, NK_UP);
+            nk_console_knob_set_dead_zone_degrees(knob_float, 45.0f);
             nk_console_button_onclick(properties, "Back", &nk_console_button_back);
         }
 

--- a/nuklear_console_knob.h
+++ b/nuklear_console_knob.h
@@ -26,6 +26,26 @@ NK_API nk_console* nk_console_knob_int(nk_console* parent, const char* label, in
  */
 NK_API nk_console* nk_console_knob_float(nk_console* parent, const char* label, float min, float* val, float max, float step, float inc_per_pixel);
 
+/**
+ * Gets the zero direction of a Knob widget.
+ */
+NK_API enum nk_heading nk_console_knob_get_zero_direction(nk_console* knob);
+
+/**
+ * Sets the zero direction of a Knob widget.
+ */
+NK_API void nk_console_knob_set_zero_direction(nk_console* knob, enum nk_heading zero_direction);
+
+/**
+ * Gets the dead zone degrees of a Knob widget.
+ */
+NK_API float nk_console_knob_get_dead_zone_degrees(nk_console* knob);
+
+/**
+ * Sets the dead zone degrees of a Knob widget.
+ */
+NK_API void nk_console_knob_set_dead_zone_degrees(nk_console* knob, float dead_zone_degrees);
+
 #if defined(__cplusplus)
 }
 #endif
@@ -92,6 +112,38 @@ NK_API nk_console* nk_console_knob_float(nk_console* parent, const char* label, 
     }
 
     return widget;
+}
+
+NK_API enum nk_heading nk_console_knob_get_zero_direction(nk_console* knob) {
+    if (knob == NULL || knob->data == NULL) {
+        return NK_DOWN;
+    }
+    nk_console_knob_data* data = (nk_console_knob_data*)knob->data;
+    return data->zero_direction;
+}
+
+NK_API void nk_console_knob_set_zero_direction(nk_console* knob, enum nk_heading zero_direction) {
+    if (knob == NULL || knob->data == NULL) {
+        return;
+    }
+    nk_console_knob_data* data = (nk_console_knob_data*)knob->data;
+    data->zero_direction = zero_direction;
+}
+
+NK_API float nk_console_knob_get_dead_zone_degrees(nk_console* knob) {
+    if (knob == NULL || knob->data == NULL) {
+        return 60.0f;
+    }
+    nk_console_knob_data* data = (nk_console_knob_data*)knob->data;
+    return data->dead_zone_degrees;
+}
+
+NK_API void nk_console_knob_set_dead_zone_degrees(nk_console* knob, float dead_zone_degrees) {
+    if (knob == NULL || knob->data == NULL) {
+        return;
+    }
+    nk_console_knob_data* data = (nk_console_knob_data*)knob->data;
+    data->dead_zone_degrees = dead_zone_degrees;
 }
 
 #if defined(__cplusplus)

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -472,6 +472,22 @@ int main() {
         static float knob_float_val = 0.5f;
         nk_console* knob_float = nk_console_knob_float(console, "Knob Float", 0.0f, &knob_float_val, 1.0f, 0.1f, 1.0f);
         assert(knob_float != NULL);
+
+        // Knob accessor defaults
+        assert(nk_console_knob_get_zero_direction(knob_int) == NK_DOWN);
+        assert(nk_console_knob_get_dead_zone_degrees(knob_int) == 60.0f);
+
+        // Knob accessor set/get round-trip
+        nk_console_knob_set_zero_direction(knob_int, NK_UP);
+        assert(nk_console_knob_get_zero_direction(knob_int) == NK_UP);
+        nk_console_knob_set_dead_zone_degrees(knob_float, 45.0f);
+        assert(nk_console_knob_get_dead_zone_degrees(knob_float) == 45.0f);
+
+        // NULL safety
+        nk_console_knob_set_zero_direction(NULL, NK_LEFT);
+        nk_console_knob_set_dead_zone_degrees(NULL, 90.0f);
+        assert(nk_console_knob_get_zero_direction(NULL) == NK_DOWN);
+        assert(nk_console_knob_get_dead_zone_degrees(NULL) == 60.0f);
     }
 
     // nk_console_radio()


### PR DESCRIPTION
Add get/set accessors for zero_direction and dead_zone_degrees on knob widgets, with tests. Fixes #280