### PR TITLE
docs: sync README sigs, add missing prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ nk_console* nk_console_init(struct nk_context* context);
 void nk_console_free(nk_console* console);
 void nk_console_free_children(nk_console* console);
 void nk_console_render(nk_console* console);
-void nk_console_render_window(nk_console* console, const char* title, struct nk_rect bounds, nk_uint flags);
+struct nk_rect nk_console_render_window(nk_console* console, const char* title, struct nk_rect bounds, nk_uint flags);
 
 // Widgets
 nk_console* nk_console_button(nk_console* parent, const char* text);
@@ -93,7 +93,7 @@ nk_console* nk_console_textedit(nk_console* parent, const char* label, char* buf
 nk_console* nk_console_tree(nk_console* parent, const char* label, nk_bool expanded);
 
 // Utilities
-void nk_console_button_back(nk_console* button);
+void nk_console_button_back(nk_console* button, void* user_data);
 nk_console* nk_console_get_top(nk_console* widget);
 int nk_console_get_widget_index(nk_console* widget);
 int nk_console_height(nk_console* widget);

--- a/nuklear_console_list_view.h
+++ b/nuklear_console_list_view.h
@@ -111,6 +111,14 @@ NK_API void nk_console_list_view_set_searchable(nk_console* list_view, nk_bool s
  */
 NK_API void nk_console_list_view_set_selected(nk_console* list_view, nk_uint index);
 
+/**
+ * Render a list view widget.
+ *
+ * @param widget The List View widget to render.
+ * @return The bounding rectangle used for layout.
+ */
+NK_API struct nk_rect nk_console_list_view_render(nk_console* widget);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -58,6 +58,16 @@ NK_API void nk_console_set_message_position(nk_console* console, nk_console_mess
  */
 NK_API nk_console_message_position nk_console_get_message_position(nk_console* console);
 
+/**
+ * Render a single message notification.
+ */
+NK_API void nk_console_message_render(nk_console* console, nk_console_message* message);
+
+/**
+ * Render all active messages for the console.
+ */
+NK_API void nk_console_render_message(nk_console* console);
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
Fix render_window return type and button_back signature in README. Add missing prototypes for list_view_render, message_render, and render_message. Fixes #278