### PR TITLE
message: stable slide on zero-delta frames

### DIFF
--- a/nuklear_console.h
+++ b/nuklear_console.h
@@ -156,6 +156,15 @@ typedef struct nk_console_top_data {
     nk_console_message_position message_position;
 
     /**
+     * True once a positive delta time has been observed, meaning the backend
+     * provides timing and messages can animate. Keeps message positioning
+     * stable on frames that report a zero delta (e.g. SDL's millisecond tick
+     * resolution at high frame rates), and disables the slide animation
+     * entirely on backends without timing.
+     */
+    nk_bool message_time_observed;
+
+    /**
      * The gamepad system to use for gamepad input.
      *
      * @see nk_console_get_gamepads()

--- a/nuklear_console_message.h
+++ b/nuklear_console_message.h
@@ -128,6 +128,36 @@ NK_API void nk_console_show_message(nk_console* console, const char* text) {
 #define NK_CONSOLE_MESSAGE_SCROLL_PAUSE NK_CONSOLE_MARQUEE_SCROLL_PAUSE
 #endif
 
+/**
+ * The eased slide fraction (0..1) of a message's in/out animation: 1 fully
+ * off its edge, 0 resting on screen.
+ *
+ * The fraction is a pure function of the message's remaining duration, so
+ * frames that report a zero delta time (e.g. SDL's millisecond tick
+ * resolution at high frame rates) keep the same offset instead of snapping
+ * the message to its resting position (#301). Backends without timing never
+ * observe a delta, and their messages simply rest on screen.
+ */
+static float nk_console_message_slide_fraction(nk_console_top_data* data, nk_console_message* message) {
+    if (data == NULL || message == NULL || data->message_time_observed == nk_false) {
+        return 0.0f;
+    }
+    float t = 0.0f;
+    if (message->duration <= 1.0f) {
+        // Slide out: t goes 0->1 as duration drops from 1->0.
+        t = 1.0f - message->duration;
+    }
+    else if (message->duration >= NK_CONSOLE_MESSAGE_DURATION - 1.0f) {
+        // Slide in: t goes 1->0 as duration drops from DURATION->DURATION-1.
+        t = message->duration - NK_CONSOLE_MESSAGE_DURATION + 1.0f;
+    }
+    if (t <= 0.0f) {
+        return 0.0f;
+    }
+    // Smoothstep easing: t*t*(3-2t)
+    return t * t * (3.0f - 2.0f * t);
+}
+
 NK_API void nk_console_message_render(nk_console* console, nk_console_message* message) {
     if (message == NULL || console->data == NULL) {
         return;
@@ -153,34 +183,22 @@ NK_API void nk_console_message_render(nk_console* console, nk_console_message* m
     ctx->input.mouse.pos.y = (position == NK_CONSOLE_MESSAGE_POSITION_BOTTOM) ? bounds.y + bounds.h - slide_h : bounds.y;
 
     // Slide the message off its anchored edge as it animates in and out.
-    if (ctx->delta_time_seconds > 0) {
-        float t = 0.0f;
-        if (message->duration <= 1.0f) {
-            // Slide out: t goes 0->1 as duration drops from 1->0.
-            t = 1.0f - message->duration;
-        }
-        else if (message->duration >= NK_CONSOLE_MESSAGE_DURATION - 1.0f) {
-            // Slide in: t goes 1->0 as duration drops from DURATION->DURATION-1.
-            t = message->duration - NK_CONSOLE_MESSAGE_DURATION + 1.0f;
-        }
-        if (t > 0.0f) {
-            // Smoothstep easing: t_s = t*t*(3-2t)
-            float t_s = t * t * (3.0f - 2.0f * t);
-            switch (position) {
-                case NK_CONSOLE_MESSAGE_POSITION_TOP:
-                    ctx->input.mouse.pos.y -= (int)(t_s * slide_h);
-                    break;
-                case NK_CONSOLE_MESSAGE_POSITION_LEFT:
-                    ctx->input.mouse.pos.x -= (int)(t_s * bounds.w);
-                    break;
-                case NK_CONSOLE_MESSAGE_POSITION_RIGHT:
-                    ctx->input.mouse.pos.x += (int)(t_s * bounds.w);
-                    break;
-                case NK_CONSOLE_MESSAGE_POSITION_BOTTOM:
-                default:
-                    ctx->input.mouse.pos.y += (int)(t_s * slide_h);
-                    break;
-            }
+    float t_s = nk_console_message_slide_fraction(data, message);
+    if (t_s > 0.0f) {
+        switch (position) {
+            case NK_CONSOLE_MESSAGE_POSITION_TOP:
+                ctx->input.mouse.pos.y -= (int)(t_s * slide_h);
+                break;
+            case NK_CONSOLE_MESSAGE_POSITION_LEFT:
+                ctx->input.mouse.pos.x -= (int)(t_s * bounds.w);
+                break;
+            case NK_CONSOLE_MESSAGE_POSITION_RIGHT:
+                ctx->input.mouse.pos.x += (int)(t_s * bounds.w);
+                break;
+            case NK_CONSOLE_MESSAGE_POSITION_BOTTOM:
+            default:
+                ctx->input.mouse.pos.y += (int)(t_s * slide_h);
+                break;
         }
     }
 
@@ -195,6 +213,13 @@ NK_API void nk_console_message_render(nk_console* console, nk_console_message* m
 
 NK_API void nk_console_render_message(nk_console* console) {
     nk_console_top_data* data = (nk_console_top_data*)console->data;
+
+    // Remember that the backend provides timing, so message positioning stays
+    // animated even on frames that report a zero delta.
+    if (console->ctx->delta_time_seconds > 0) {
+        data->message_time_observed = nk_true;
+    }
+
     if (data->messages == NULL || cvector_empty(data->messages)) {
         return;
     }

--- a/test/nuklear_console_test.c
+++ b/test/nuklear_console_test.c
@@ -435,6 +435,44 @@ int main() {
         assert(nk_strlen(last_msg->text) == NK_CONSOLE_MESSAGE_MAX_LENGTH);
     }
 
+    // nk_console_message_slide_fraction() (#301)
+    {
+        nk_console_top_data* top_data = (nk_console_top_data*)(nk_console_get_top(console)->data);
+        nk_console_message msg;
+        memset(&msg, 0, sizeof(msg));
+
+        // Without observed timing, messages rest on screen at any duration.
+        nk_bool saved_observed = top_data->message_time_observed;
+        top_data->message_time_observed = nk_false;
+        msg.duration = NK_CONSOLE_MESSAGE_DURATION;
+        assert(nk_console_message_slide_fraction(top_data, &msg) == 0.0f);
+        msg.duration = 0.5f;
+        assert(nk_console_message_slide_fraction(top_data, &msg) == 0.0f);
+
+        // With timing, the fraction is a pure function of the duration, so a
+        // zero-delta frame keeps the same offset instead of snapping to rest.
+        top_data->message_time_observed = nk_true;
+        msg.duration = NK_CONSOLE_MESSAGE_DURATION;
+        assert(nk_console_message_slide_fraction(top_data, &msg) == 1.0f);
+        float mid_in = nk_console_message_slide_fraction(top_data, &msg);
+        msg.duration = NK_CONSOLE_MESSAGE_DURATION - 0.5f;
+        float half_in = nk_console_message_slide_fraction(top_data, &msg);
+        assert(half_in > 0.0f && half_in < mid_in);
+        msg.duration = NK_CONSOLE_MESSAGE_DURATION * 0.5f;
+        assert(nk_console_message_slide_fraction(top_data, &msg) == 0.0f); // Resting.
+        msg.duration = 0.5f;
+        float half_out = nk_console_message_slide_fraction(top_data, &msg);
+        assert(half_out > 0.0f && half_out < 1.0f);
+        msg.duration = 0.0f;
+        assert(nk_console_message_slide_fraction(top_data, &msg) == 1.0f);
+
+        // NULL safety.
+        assert(nk_console_message_slide_fraction(NULL, &msg) == 0.0f);
+        assert(nk_console_message_slide_fraction(top_data, NULL) == 0.0f);
+
+        top_data->message_time_observed = saved_observed;
+    }
+
     // nk_console_set_message_position() / nk_console_get_message_position()
     {
         assert(nk_console_get_message_position(console) == NK_CONSOLE_MESSAGE_POSITION_BOTTOM);


### PR DESCRIPTION
Makes the message slide offset a pure function of the message duration instead of skipping it on frames that report a zero delta time (SDL's millisecond tick resolution at high frame rates), which made messages jump between their animated and resting positions. Fixes #301