### PR TITLE
Expand .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,33 @@
+# Build output
 bin
+build*/
 *.o
-build
+*.a
+*.so
+*.dylib
+
+# CMake
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+compile_commands.json
+CTestTestfile.cmake
+DartConfiguration.tcl
+_deps/
+Testing/
+
+# Demos and documentation
 nuklear_console_demo_*
 *.gif
 screenshot*
 package-lock.json
 node_modules
 wiki
+
+# Editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store


### PR DESCRIPTION
Covers `build*/` variants, compiled libraries, in-source CMake output, and editor temporaries; tracked Makefiles are intentionally not ignored. Fixes #303